### PR TITLE
LPS-96358 portal-search-tuning-rankings-web: Add activate/deactivate

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/constants/ResultRankingsConstants.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/constants/ResultRankingsConstants.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.portal.search.tuning.rankings.web.internal.constants;
+
+/**
+ * @author Olivia Yu
+ */
+public class ResultRankingsConstants {
+
+	public static final String ACTIVATE = "activate";
+
+	public static final String DEACTIVATE = "deactivate";
+
+}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/display/context/RankingPortletDisplayBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/display/context/RankingPortletDisplayBuilder.java
@@ -113,6 +113,25 @@ public class RankingPortletDisplayBuilder {
 				add(
 					dropdownItem -> {
 						dropdownItem.putData(
+							"action", "deactivateResultsRankingsEntries");
+						dropdownItem.setIcon("hidden");
+						dropdownItem.setLabel(
+							LanguageUtil.get(
+								_httpServletRequest, "deactivate"));
+						dropdownItem.setQuickAction(true);
+					});
+				add(
+					dropdownItem -> {
+						dropdownItem.putData(
+							"action", "activateResultsRankingsEntries");
+						dropdownItem.setIcon("undo");
+						dropdownItem.setLabel(
+							LanguageUtil.get(_httpServletRequest, "activate"));
+						dropdownItem.setQuickAction(true);
+					});
+				add(
+					dropdownItem -> {
+						dropdownItem.putData(
 							"action", "deleteResultsRankingsEntries");
 						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view_results_rankings.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view_results_rankings.jsp
@@ -24,6 +24,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
+page import="com.liferay.portal.search.tuning.rankings.web.internal.constants.ResultRankingsConstants" %><%@
 page import="com.liferay.portal.search.tuning.rankings.web.internal.constants.ResultRankingsPortletKeys" %><%@
 page import="com.liferay.portal.search.tuning.rankings.web.internal.display.context.RankingEntryDisplayContext" %><%@
 page import="com.liferay.portal.search.tuning.rankings.web.internal.display.context.RankingPortletDisplayContext" %>
@@ -49,12 +50,22 @@ RankingPortletDisplayContext rankingPortletDisplayContext = (RankingPortletDispl
 	showSearch="<%= false %>"
 />
 
+<portlet:actionURL name="/results_ranking/edit" var="activateResultsRankingEntryURL">
+	<portlet:param name="<%= Constants.CMD %>" value="<%= ResultRankingsConstants.ACTIVATE %>" />
+	<portlet:param name="redirect" value="<%= currentURL %>" />
+</portlet:actionURL>
+
+<portlet:actionURL name="/results_ranking/edit" var="deactivateResultsRankingEntryURL">
+	<portlet:param name="<%= Constants.CMD %>" value="<%= ResultRankingsConstants.DEACTIVATE %>" />
+	<portlet:param name="redirect" value="<%= currentURL %>" />
+</portlet:actionURL>
+
 <portlet:actionURL name="/results_ranking/edit" var="deleteResultsRankingEntryURL">
 	<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.DELETE %>" />
 	<portlet:param name="redirect" value="<%= currentURL %>" />
 </portlet:actionURL>
 
-<aui:form action="<%= deleteResultsRankingEntryURL %>" cssClass="container-fluid-1280" method="post" name="resultsRankingEntriesFm">
+<aui:form cssClass="container-fluid-1280" method="post" name="resultsRankingEntriesFm">
 	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
 	<liferay-ui:search-container
@@ -136,24 +147,56 @@ RankingPortletDisplayContext rankingPortletDisplayContext = (RankingPortletDispl
 	</liferay-ui:search-container>
 </aui:form>
 
-<aui:script>
+<aui:script sandbox="<%= true %>">
+	var submitForm = function(url) {
+		var searchContainer = document.getElementById(
+			'<portlet:namespace />resultsRankingEntries'
+		);
+
+		if (searchContainer) {
+			Liferay.Util.postForm(
+				document.<portlet:namespace />resultsRankingEntriesFm,
+				{
+					data: {
+						actionFormInstanceIds: Liferay.Util.listCheckedExcept(
+							searchContainer,
+							'<portlet:namespace />allRowIds'
+						)
+					},
+
+					url: url
+				}
+			);
+		}
+	};
+
+	var activateResultsRankingsEntries = function() {
+		submitForm('<%= activateResultsRankingEntryURL %>');
+	};
+
+	var deactivateResultsRankingsEntries = function() {
+		if (
+			confirm(
+				'<liferay-ui:message key="are-you-sure-you-want-to-deactivate-this" />'
+			)
+		) {
+			submitForm('<%= deactivateResultsRankingEntryURL %>');
+		}
+	};
+
 	var deleteResultsRankingsEntries = function() {
 		if (
 			confirm(
 				'<liferay-ui:message key="are-you-sure-you-want-to-delete-this" />'
 			)
 		) {
-			var form = document.querySelector(
-				'#<portlet:namespace />resultsRankingEntriesFm'
-			);
-
-			if (form) {
-				submitForm(form);
-			}
+			submitForm('<%= deleteResultsRankingEntryURL %>');
 		}
 	};
 
 	var ACTIONS = {
+		activateResultsRankingsEntries: activateResultsRankingsEntries,
+		deactivateResultsRankingsEntries: deactivateResultsRankingsEntries,
 		deleteResultsRankingsEntries: deleteResultsRankingsEntries
 	};
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view_results_rankings_entry_action.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view_results_rankings_entry_action.jsp
@@ -24,6 +24,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 page import="com.liferay.portal.kernel.dao.search.ResultRow" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
+page import="com.liferay.portal.search.tuning.rankings.web.internal.constants.ResultRankingsConstants" %><%@
 page import="com.liferay.portal.search.tuning.rankings.web.internal.display.context.RankingEntryDisplayContext" %>
 
 <liferay-frontend:defineObjects />
@@ -56,6 +57,17 @@ RankingEntryDisplayContext rankingEntryDisplayContext = (RankingEntryDisplayCont
 	<liferay-ui:icon
 		message="edit"
 		url="<%= editURL %>"
+	/>
+
+	<portlet:actionURL name="/results_ranking/edit" var="deactivateURL">
+		<portlet:param name="<%= Constants.CMD %>" value="<%= rankingEntryDisplayContext.getInactive() ? ResultRankingsConstants.ACTIVATE : ResultRankingsConstants.DEACTIVATE %>" />
+		<portlet:param name="redirect" value="<%= currentURL %>" />
+		<portlet:param name="resultsRankingUid" value="<%= rankingEntryDisplayContext.getUid() %>" />
+	</portlet:actionURL>
+
+	<liferay-ui:icon
+		message="<%= rankingEntryDisplayContext.getInactive() ? ResultRankingsConstants.ACTIVATE : ResultRankingsConstants.DEACTIVATE %>"
+		url="<%= deactivateURL %>"
 	/>
 
 	<portlet:actionURL name="/results_ranking/edit" var="deleteURL">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-96358

From Dennis: 

1. Add "Deactivate" and "Activate" menu items to the action menu. The menu item should go between the "Edit" and "Delete" menu items (so the order will be "Edit", "Activate"/"Deactivate", "Delete").
2. Add "Deactivate" and "Activate" to the quick action menu when items are selected? Use the same icons for activating/deactivating users from the "Users > Users and Organizations" portlet (unless we have updated Clay icons that are more appropriate).

@jonmak08