### PR TITLE
LPS-114076 portal-search-tuning-synonims-web - Replace HTML with ClayLayout

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/js/components/SynonymSetsForm.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/js/components/SynonymSetsForm.es.js
@@ -11,6 +11,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
+import ClayLayout from '@clayui/layout';
 import ClayMultiSelect from '@clayui/multi-select';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
@@ -115,63 +116,61 @@ class SynonymSetsForm extends Component {
 
 		return (
 			<div className="synonym-sets-form">
-				<div className="container-fluid-max-xl">
-					<div className="sheet-lg">
-						<div className="sheet-title">
-							{Liferay.Language.get('create-synonym-set')}
-						</div>
-
-						<div className="sheet-text">
-							{Liferay.Language.get(
-								'broaden-the-scope-of-search-by-treating-terms-equally-using-synonyms'
-							)}
-						</div>
-
-						<ClayForm.Group>
-							<label htmlFor="synonym-sets-input">
-								{Liferay.Language.get('synonyms')}
-							</label>
-
-							<ClayInput.Group>
-								<ClayInput.GroupItem>
-									<ClayMultiSelect
-										id="synonym-sets-input"
-										inputValue={inputValue}
-										items={synonyms}
-										onChange={this._handleInputChange}
-										onItemsChange={this._handleItemsChange}
-									/>
-
-									<ClayForm.FeedbackGroup>
-										<ClayForm.Text>
-											{Liferay.Language.get(
-												'type-a-comma-or-press-enter-to-input-a-synonym'
-											)}
-										</ClayForm.Text>
-									</ClayForm.FeedbackGroup>
-								</ClayInput.GroupItem>
-							</ClayInput.Group>
-						</ClayForm.Group>
-
-						<div className="sheet-footer">
-							<ClayButton
-								disabled={synonyms.length === 0}
-								displayType="primary"
-								onClick={this._handleSubmit}
-								type="submit"
-							>
-								{Liferay.Language.get('publish')}
-							</ClayButton>
-
-							<ClayButton
-								displayType="secondary"
-								onClick={this._handleCancel}
-							>
-								{Liferay.Language.get('cancel')}
-							</ClayButton>
-						</div>
+				<ClayLayout.ContainerFluid>
+					<div className="sheet-title">
+						{Liferay.Language.get('create-synonym-set')}
 					</div>
-				</div>
+
+					<div className="sheet-text">
+						{Liferay.Language.get(
+							'broaden-the-scope-of-search-by-treating-terms-equally-using-synonyms'
+						)}
+					</div>
+
+					<ClayForm.Group>
+						<label htmlFor="synonym-sets-input">
+							{Liferay.Language.get('synonyms')}
+						</label>
+
+						<ClayInput.Group>
+							<ClayInput.GroupItem>
+								<ClayMultiSelect
+									id="synonym-sets-input"
+									inputValue={inputValue}
+									items={synonyms}
+									onChange={this._handleInputChange}
+									onItemsChange={this._handleItemsChange}
+								/>
+
+								<ClayForm.FeedbackGroup>
+									<ClayForm.Text>
+										{Liferay.Language.get(
+											'type-a-comma-or-press-enter-to-input-a-synonym'
+										)}
+									</ClayForm.Text>
+								</ClayForm.FeedbackGroup>
+							</ClayInput.GroupItem>
+						</ClayInput.Group>
+					</ClayForm.Group>
+
+					<ClayLayout.SheetFooter>
+						<ClayButton
+							disabled={synonyms.length === 0}
+							displayType="primary"
+							onClick={this._handleSubmit}
+							type="submit"
+						>
+							{Liferay.Language.get('publish')}
+						</ClayButton>
+
+						<ClayButton
+							displayType="secondary"
+							onClick={this._handleCancel}
+						>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+					</ClayLayout.SheetFooter>
+				</ClayLayout.ContainerFluid>
 			</div>
 		);
 	}


### PR DESCRIPTION
Hey @thektan can you please review this.

I've replaced:
- `div.container-fluid-max-xl` with  `ClayLayout.ContainerFluid`
- `div.sheet-footer` with `ClayLayout.SheetFooter`

Things that we have no replacements for:
- `sheet-text`
- `sheet-title`

### sheet-lg
I've removed `div.sheet-lg` because it wasn't providing any value to the DOM. Sheet styles are being applied to the parent, above the form, constraining this component's width, and margins. Basically, as far as my investigation led me to believe, the extra div wasn't doing anything, even on mobile resolution.
Initially I made the it a `ClayLayout.Sheet` but that puts a `sheet` inside a `sheet` and that's not the desired result.