### PR TITLE
LPS-114556 - Incorrect error message for modified facet widget

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/modified_facet.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/modified_facet.js
@@ -18,7 +18,6 @@ AUI.add(
 		var DEFAULTS_FORM_VALIDATOR = A.config.FormValidator;
 
 		var FacetUtil = Liferay.Search.FacetUtil;
-		var Language = Liferay.Language;
 		var Util = Liferay.Util;
 
 		var ModifiedFacetFilter = function (config) {
@@ -62,7 +61,7 @@ AUI.add(
 				A.mix(
 					DEFAULTS_FORM_VALIDATOR.STRINGS,
 					{
-						[dateRangeRuleName]: Language.get(
+						[dateRangeRuleName]: Liferay.Language.get(
 							'search-custom-range-invalid-date-range'
 						),
 					},


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-114556

According to changes on https://issues.liferay.com/browse/LPS-113569, `Liferay.Language.get` is now a noop on the js side https://github.com/liferay/liferay-portal/commit/6b1ccee0f60bab78fa568e082f7f92483b6b273b#diff-bb8e27c8d2b469937c2b3f28f29c2700R99-R102, so it relies on the filter to replace `Liferay.Language.get`.

cc @jonmak08