### PR TITLE
LPS-116954 portal-search-tuning-gsearch-configuration-web: Update builder and fragments

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/css/_builder.scss
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/css/_builder.scss
@@ -3,18 +3,21 @@
 	padding-top: 6rem;
 
 	.configuration-fragment {
-		background-color: $white;
-		margin-bottom: 1.5rem;
+		margin-bottom: 1rem;
+		padding: 0;
 
 		.configuration-editor {
-			padding-bottom: 1.5rem;
-			padding-left: 1rem;
-			padding-right: 1rem;
+			padding: 0 1.5rem 1rem 1.5rem;
+
+			.ace-editor {
+				background-color: $secondaryHover;
+				border: 0.0625rem $mainLighten74 solid;
+				border-radius: 0.25rem;
+			}
 		}
 
 		.list-group {
-			margin-bottom: 0;
-			padding: 0.5rem 0;
+			margin: 0.5rem 0;
 
 			.list-group-item {
 				border: 0;
@@ -23,8 +26,14 @@
 	}
 
 	.configuration-header {
-		margin-bottom: 1rem;
-		padding-top: 1rem;
+		margin-bottom: 1.25rem;
+
+		button {
+			color: $mainLighten28;
+			float: right;
+			font-size: 0.875rem;
+			margin: 0.125rem 1rem 0 0;
+		}
 	}
 }
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/Builder.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/Builder.js
@@ -9,71 +9,44 @@
  * distribution rights of the Software.
  */
 
+import ClayButton from '@clayui/button';
 import ClayLayout from '@clayui/layout';
-import React from 'react';
+import {PropTypes} from 'prop-types';
+import React, {useState} from 'react';
 
 import Fragment from './Fragment';
 
-export default function Builder() {
-	const queryFragments = [
-		{
-			description:
-				'broadest-query-catching-documents-matching-any-keyword-title-is-given-more-boost-among-the-fields-query-has-the-neutral-boost-of-1.0',
-			icon: 'vocabulary',
-			json: {
-				clauses: [
-					{
-						configuration: {
-							boost: 20,
-							field_name:
-								'gsearch_locations_$_context.language_id_$',
-							query: '$_geolocation.city_$',
-						},
-						occur: 'should',
-						query_type: 'match',
-					},
-					{
-						configuration: {
-							boost: 10,
-							field_name:
-								'gsearch_locations_$_context.language_id_$',
-							query: '$_geolocation.country_name_$',
-						},
-						occur: 'should',
-						query_type: 'match',
-					},
-				],
-				conditions: [],
-				description:
-					'Example of using geolocation clause condition and configuration variables. Requires the gsearch-geolocation module.',
-				enabled: true,
-			},
-			title: 'matches-any-keyword',
-		},
-		{
-			description: 'boost-content-last-modified-within-a-time-frame',
-			icon: 'time',
-			title: 'freshness',
-		},
-		{
-			description: "boost-content-created-closer-to-user's-location",
-			icon: 'geolocation',
-			title: "user's-geolocation",
-		},
-	];
+export default function Builder({deleteFragment, selectedFragments}) {
+	const [collapseAll, setCollapseAll] = useState(0);
 
 	return (
 		<ClayLayout.ContainerFluid className="builder" size="md">
-			<ClayLayout.SheetHeader className="bold configuration-header">
-				{Liferay.Language.get('builder')}
-			</ClayLayout.SheetHeader>
+			<ClayLayout.Row
+				className="bold configuration-header"
+				justify="between"
+			>
+				<ClayLayout.Col size={4}>
+					{Liferay.Language.get('builder')}
+				</ClayLayout.Col>
+				<ClayLayout.Col size={3}>
+					<ClayButton
+						aria-label={Liferay.Language.get('collapse-all')}
+						displayType="unstyled"
+						onClick={() => setCollapseAll(collapseAll + 1)}
+					>
+						{Liferay.Language.get('collapse-all')}
+					</ClayButton>
+				</ClayLayout.Col>
+			</ClayLayout.Row>
 
-			{queryFragments.map((item, index) => {
+			{selectedFragments.map((item, index) => {
 				return (
 					<Fragment
-						deleteURL={item.deleteURL}
+						collapse={collapseAll}
+						deleteFragment={deleteFragment}
 						description={item.description}
 						icon={item.icon}
+						json={item.json}
 						key={index}
 						title={item.title}
 					/>
@@ -82,3 +55,8 @@ export default function Builder() {
 		</ClayLayout.ContainerFluid>
 	);
 }
+
+Builder.propTypes = {
+	deleteFragment: PropTypes.func,
+	selectedFragments: PropTypes.arrayOf(PropTypes.object),
+};

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/ConfigurationSetForm.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/ConfigurationSetForm.js
@@ -22,6 +22,124 @@ export default function ConfigurationSetForm({
 	initialTitleTranslations = {},
 }) {
 	const [showSidebar] = useState(true);
+	const [selectedFragments, setSelectedFragments] = useState([]);
+
+	const queryFragments = [
+		{
+			description:
+				'broadest-query-catching-documents-matching-any-keyword-title-is-given-more-boost-among-the-fields-query-has-the-neutral-boost-of-1.0',
+			icon: 'vocabulary',
+			json: {
+				clauses: [
+					{
+						configuration: {
+							boost: 20,
+							field_name:
+								'gsearch_locations_$_context.language_id_$',
+							query: '$_geolocation.city_$',
+						},
+						occur: 'should',
+						query_type: 'match',
+					},
+					{
+						configuration: {
+							boost: 10,
+							field_name:
+								'gsearch_locations_$_context.language_id_$',
+							query: '$_geolocation.country_name_$',
+						},
+						occur: 'should',
+						query_type: 'match',
+					},
+				],
+				conditions: [],
+				description:
+					'Example of using geolocation clause condition and configuration variables. Requires the gsearch-geolocation module.',
+				enabled: true,
+			},
+			title: 'matches-any-keyword',
+		},
+		{
+			description: 'boost-content-last-modified-within-a-time-frame',
+			icon: 'time',
+			json: {
+				clauses: [
+					{
+						configuration: {
+							boost: 20,
+							field_name:
+								'gsearch_locations_$_context.language_id_$',
+							query: '$_geolocation.city_$',
+						},
+						occur: 'should',
+						query_type: 'match',
+					},
+					{
+						configuration: {
+							boost: 10,
+							field_name:
+								'gsearch_locations_$_context.language_id_$',
+							query: '$_geolocation.country_name_$',
+						},
+						occur: 'should',
+						query_type: 'match',
+					},
+				],
+				conditions: [],
+				description:
+					'Example of using geolocation clause condition and configuration variables. Requires the gsearch-geolocation module.',
+				enabled: true,
+			},
+			title: 'freshness',
+		},
+		{
+			description: "boost-content-created-closer-to-user's-location",
+			icon: 'geolocation',
+			json: {
+				clauses: [
+					{
+						configuration: {
+							boost: 20,
+							field_name:
+								'gsearch_locations_$_context.language_id_$',
+							query: '$_geolocation.city_$',
+						},
+						occur: 'should',
+						query_type: 'match',
+					},
+					{
+						configuration: {
+							boost: 10,
+							field_name:
+								'gsearch_locations_$_context.language_id_$',
+							query: '$_geolocation.country_name_$',
+						},
+						occur: 'should',
+						query_type: 'match',
+					},
+				],
+				conditions: [],
+				description:
+					'Example of using geolocation clause condition and configuration variables. Requires the gsearch-geolocation module.',
+				enabled: true,
+			},
+			title: "user's-geolocation",
+		},
+	];
+
+	const fragmentMap = queryFragments.reduce((acc, cur) => {
+		return acc[cur.title] ? acc : {...acc, [cur.title]: cur};
+	}, {});
+
+	function addFragment(id) {
+		if (!selectedFragments.includes(id)) {
+			setSelectedFragments([...selectedFragments, id]);
+		}
+	}
+
+	function deleteFragment(id) {
+		setSelectedFragments(selectedFragments.filter((item) => item !== id));
+	}
 
 	function handlePublish() {
 		submitForm(document[formName]);
@@ -35,10 +153,20 @@ export default function ConfigurationSetForm({
 				onPublish={handlePublish} //will depend on required values
 			/>
 
-			{showSidebar && <Sidebar />}
+			{showSidebar && (
+				<Sidebar
+					addFragment={addFragment}
+					queryFragments={queryFragments}
+				/>
+			)}
 
 			<div className={`${showSidebar ? 'shifted' : ''}`}>
-				<Builder />
+				<Builder
+					deleteFragment={deleteFragment}
+					selectedFragments={selectedFragments.map(
+						(id) => fragmentMap[id]
+					)}
+				/>
 			</div>
 		</>
 	);

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/Fragment.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/Fragment.js
@@ -15,7 +15,7 @@ import ClayIcon from '@clayui/icon';
 import ClayList from '@clayui/list';
 import ClaySticker from '@clayui/sticker';
 import {PropTypes} from 'prop-types';
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 class AceEditor extends React.Component {
 	constructor(props) {
@@ -28,11 +28,10 @@ class AceEditor extends React.Component {
 		AUI().use('aui-ace-editor', (A) => {
 			const editor = new A.AceEditor({
 				boundingBox: this.container.current,
-				highlightActiveLine: false,
 				mode: 'json',
-				readOnly: 'false',
+				readOnly: false,
 				tabSize: 4,
-				value: this.props.json,
+				value: JSON.stringify(this.props.value, null, '\t'),
 				width: '100%',
 			}).render();
 
@@ -57,19 +56,32 @@ class AceEditor extends React.Component {
 }
 
 AceEditor.propTypes = {
-	json: PropTypes.string,
 	onRender: PropTypes.func,
+	value: PropTypes.object,
 };
 
-export default function Fragment({deleteURL, description, icon, json, title}) {
+export default function Fragment({
+	collapse,
+	deleteFragment,
+	description,
+	icon,
+	json,
+	title,
+}) {
 	const [active, setActive] = useState(false);
 	const [expand, setExpand] = useState(true);
 
 	const editorElementRef = useRef();
 	const editorTextInputRef = useRef();
 
+	useEffect(() => {
+		if (collapse) {
+			setExpand(false);
+		}
+	}, [collapse]);
+
 	return (
-		<div className="configuration-fragment" key={title}>
+		<div className="configuration-fragment sheet" key={title}>
 			<ClayList>
 				<ClayList.Item flex>
 					<ClayList.ItemField>
@@ -104,7 +116,9 @@ export default function Fragment({deleteURL, description, icon, json, title}) {
 						}
 					>
 						<ClayDropDown.ItemList>
-							<ClayDropDown.Item href={deleteURL}>
+							<ClayDropDown.Item
+								onClick={() => deleteFragment(title)}
+							>
 								{Liferay.Language.get('delete')}
 							</ClayDropDown.Item>
 						</ClayDropDown.ItemList>
@@ -124,23 +138,26 @@ export default function Fragment({deleteURL, description, icon, json, title}) {
 				</ClayList.Item>
 			</ClayList>
 
-			<div className="configuration-editor">
-				<AceEditor
-					json={json}
-					onRender={({editorElement, editorTextInput}) => {
-						editorElementRef.current = editorElement;
-						editorTextInputRef.current = editorTextInput;
-					}}
-				/>
-			</div>
+			{expand && (
+				<div className="configuration-editor">
+					<AceEditor
+						onRender={({editorElement, editorTextInput}) => {
+							editorElementRef.current = editorElement;
+							editorTextInputRef.current = editorTextInput;
+						}}
+						value={json}
+					/>
+				</div>
+			)}
 		</div>
 	);
 }
 
 Fragment.propTypes = {
-	deleteURL: PropTypes.string,
+	collapse: PropTypes.number,
+	deleteFragment: PropTypes.func,
 	description: PropTypes.string,
 	icon: PropTypes.string,
-	json: PropTypes.string,
+	json: PropTypes.object,
 	title: PropTypes.string,
 };

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/PageToolbar.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/PageToolbar.js
@@ -102,7 +102,7 @@ export default function PageToolbar({
 }
 
 PageToolbar.propTypes = {
+	initialTitleTranslations: PropTypes.object,
 	onCancel: PropTypes.string.isRequired,
 	onPublish: PropTypes.func.isRequired,
-	titleTranslations: PropTypes.object,
 };

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/Sidebar.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/Sidebar.js
@@ -16,26 +16,8 @@ import ClayList from '@clayui/list';
 import ClaySticker from '@clayui/sticker';
 import React, {useState} from 'react';
 
-export default function Sidebar() {
+export default function Sidebar({addFragment, queryFragments}) {
 	const [showAdd, setShowAdd] = useState(-1);
-	const queryFragments = [
-		{
-			description:
-				'broadest-query-catching-documents-matching-any-keyword-title-is-given-more-boost-among-the-fields-query-has-the-neutral-boost-of-1.0',
-			icon: 'vocabulary',
-			title: 'matches-any-keyword',
-		},
-		{
-			description: 'boost-content-last-modified-within-a-time-frame',
-			icon: 'time',
-			title: 'freshness',
-		},
-		{
-			description: "boost-content-created-closer-to-user's-location",
-			icon: 'geolocation',
-			title: "user's-geolocation",
-		},
-	];
 
 	return (
 		<div className="sidebar sidebar-light">
@@ -96,6 +78,9 @@ export default function Sidebar() {
 													'add'
 												)}
 												displayType="secondary"
+												onClick={() =>
+													addFragment(item.title)
+												}
 												small
 											>
 												{Liferay.Language.get('add')}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/test/stories/index.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/test/stories/index.es.js
@@ -30,7 +30,7 @@ import Sidebar from '../../src/main/resources/META-INF/resources/js/components/S
 
 const {addDecorator, storiesOf} = StorybookReact;
 const {action} = StorybookAddonActions;
-const {boolean, withKnobs} = StorybookAddonKnobs;
+const {withKnobs} = StorybookAddonKnobs;
 
 addDecorator(withKnobs);
 
@@ -52,32 +52,139 @@ const withContainer = (storyFn) => (
 	<ClayLayout.ContainerFluid size="md">{storyFn()}</ClayLayout.ContainerFluid>
 );
 
+const queryFragments = [
+	{
+		description:
+			'broadest-query-catching-documents-matching-any-keyword-title-is-given-more-boost-among-the-fields-query-has-the-neutral-boost-of-1.0',
+		icon: 'vocabulary',
+		json: {
+			clauses: [
+				{
+					configuration: {
+						boost: 20,
+						field_name: 'gsearch_locations_$_context.language_id_$',
+						query: '$_geolocation.city_$',
+					},
+					occur: 'should',
+					query_type: 'match',
+				},
+				{
+					configuration: {
+						boost: 10,
+						field_name: 'gsearch_locations_$_context.language_id_$',
+						query: '$_geolocation.country_name_$',
+					},
+					occur: 'should',
+					query_type: 'match',
+				},
+			],
+			conditions: [],
+			description:
+				'Example of using geolocation clause condition and configuration variables. Requires the gsearch-geolocation module.',
+			enabled: true,
+		},
+		title: 'matches-any-keyword',
+	},
+	{
+		description: 'boost-content-last-modified-within-a-time-frame',
+		icon: 'time',
+		json: {
+			clauses: [
+				{
+					configuration: {
+						boost: 20,
+						field_name: 'gsearch_locations_$_context.language_id_$',
+						query: '$_geolocation.city_$',
+					},
+					occur: 'should',
+					query_type: 'match',
+				},
+				{
+					configuration: {
+						boost: 10,
+						field_name: 'gsearch_locations_$_context.language_id_$',
+						query: '$_geolocation.country_name_$',
+					},
+					occur: 'should',
+					query_type: 'match',
+				},
+			],
+			conditions: [],
+			description:
+				'Example of using geolocation clause condition and configuration variables. Requires the gsearch-geolocation module.',
+			enabled: true,
+		},
+		title: 'freshness',
+	},
+	{
+		description: "boost-content-created-closer-to-user's-location",
+		icon: 'geolocation',
+		json: {
+			clauses: [
+				{
+					configuration: {
+						boost: 20,
+						field_name: 'gsearch_locations_$_context.language_id_$',
+						query: '$_geolocation.city_$',
+					},
+					occur: 'should',
+					query_type: 'match',
+				},
+				{
+					configuration: {
+						boost: 10,
+						field_name: 'gsearch_locations_$_context.language_id_$',
+						query: '$_geolocation.country_name_$',
+					},
+					occur: 'should',
+					query_type: 'match',
+				},
+			],
+			conditions: [],
+			description:
+				'Example of using geolocation clause condition and configuration variables. Requires the gsearch-geolocation module.',
+			enabled: true,
+		},
+		title: "user's-geolocation",
+	},
+];
+
 storiesOf('Pages|ConfigurationSetForm', module).add('default', () => (
 	<ConfigurationSetForm cancelUrl="" formName="testFm" title="" />
 ));
 
 storiesOf('Components|PageToolbar', module).add('PageToolbar', () => (
 	<PageToolbar
-		onCancel={action('onCancel')}
+		initialTitleTranslations={{}}
+		onCancel=""
 		onPublish={action('onPublish')}
-		submitDisabled={boolean('Disabled', false)}
-		titleTranslations={{}}
 	/>
 ));
 
-storiesOf('Components|Sidebar', module).add('Sidebar', () => <Sidebar />);
+storiesOf('Components|Sidebar', module).add('Sidebar', () => (
+	<Sidebar
+		addFragment={action('addFragment')}
+		queryFragments={queryFragments}
+	/>
+));
 
 storiesOf('Components|Builder', module)
 	.addDecorator(withContainer)
-	.add('Builder', () => <Builder />);
+	.add('Builder', () => (
+		<Builder
+			deleteFragment={action('buildFragment')}
+			selectedFragments={queryFragments}
+		/>
+	));
 
 storiesOf('Components|Fragment', module)
 	.addDecorator(withContainer)
 	.add('Fragment', () => (
 		<Fragment
-			deleteURL="/"
-			description="Sample description"
-			icon="time"
-			title="Sample Title"
+			deleteFragment={action('deleteFragment')}
+			description={queryFragments[0].description}
+			icon={queryFragments[0].icon}
+			json={queryFragments[0].json}
+			title={queryFragments[0].title}
 		/>
 	));


### PR DESCRIPTION
Things added so far: Styling the json editor, allowing selecting query fragments, adding collapse all button

Some things to think about:
Query fragments are just hardcoded, so I guess we need to define what fragment will be available by default. Also not sure what should happen if you delete all the fragments from the builder... empty state message or just remove 'delete' option?

Also not sure how to hook up the json editor input to what will be submitting... trying to figure out how the value will be read.