### PR TITLE
LPS-116954 portal-search-tuning-gsearch-configuration-web: UseRef

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/css/_builder.scss
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/css/_builder.scss
@@ -7,7 +7,7 @@
 		padding: 0;
 
 		.configuration-editor {
-			padding: 0 1.5rem 1rem 1.5rem;
+			padding: 0 1.5rem 1rem;
 
 			.ace-editor {
 				background-color: $secondaryHover;

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/ConfigurationSetForm.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/ConfigurationSetForm.js
@@ -16,6 +16,8 @@ import Builder from './Builder';
 import PageToolbar from './PageToolbar';
 import Sidebar from './Sidebar';
 
+const DEFAULT_FRAGMENT = 'matches-any-keyword';
+
 export default function ConfigurationSetForm({
 	availableLocales = [],
 	cancelURL = '',
@@ -23,7 +25,9 @@ export default function ConfigurationSetForm({
 	initialTitleTranslations = {},
 }) {
 	const [showSidebar] = useState(true);
-	const [selectedFragments, setSelectedFragments] = useState([]);
+	const [selectedFragments, setSelectedFragments] = useState([
+		DEFAULT_FRAGMENT,
+	]);
 
 	const queryFragments = [
 		{

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/Fragment.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/Fragment.js
@@ -17,47 +17,44 @@ import ClaySticker from '@clayui/sticker';
 import {PropTypes} from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
 
-class AceEditor extends React.Component {
-	constructor(props) {
-		super(props);
+const DEFAULT_FRAGMENT = 'matches-any-keyword';
 
-		this.container = React.createRef();
-	}
+function AceEditor({onChange, onRender, value}) {
+	const container = useRef();
 
-	componentDidMount() {
+	useEffect(() => {
 		AUI().use('aui-ace-editor', (A) => {
 			const editor = new A.AceEditor({
-				boundingBox: this.container.current,
+				boundingBox: container.current,
 				mode: 'json',
 				readOnly: false,
 				tabSize: 4,
-				value: JSON.stringify(this.props.value, null, '\t'),
+				value,
 				width: '100%',
 			}).render();
 
 			editor.on('render', () => {
-				this.props.onRender({
+				onRender({
 					editorElement: document.querySelector('.ace_editor'),
 					editorTextInput: document.querySelector('.ace_text-input'),
 				});
 			});
+
+			const session = editor.getSession();
+
+			session.on('change', () => {
+				onChange(editor.get('value'));
+			});
 		});
-	}
+	}, [onChange, onRender, value]);
 
-	shouldComponentUpdate() {
-		return false;
-	}
-
-	render() {
-		return (
-			<div className="lfr-source-editor-code" ref={this.container}></div>
-		);
-	}
+	return <div className="lfr-source-editor-code" ref={container}></div>;
 }
 
 AceEditor.propTypes = {
+	onChange: PropTypes.func,
 	onRender: PropTypes.func,
-	value: PropTypes.object,
+	value: PropTypes.string,
 };
 
 export default function Fragment({
@@ -70,6 +67,8 @@ export default function Fragment({
 }) {
 	const [active, setActive] = useState(false);
 	const [expand, setExpand] = useState(true);
+
+	const [value, setValue] = useState(JSON.stringify(json, null, '\t'));
 
 	const editorElementRef = useRef();
 	const editorTextInputRef = useRef();
@@ -117,6 +116,7 @@ export default function Fragment({
 					>
 						<ClayDropDown.ItemList>
 							<ClayDropDown.Item
+								disabled={title === DEFAULT_FRAGMENT}
 								onClick={() => deleteFragment(title)}
 							>
 								{Liferay.Language.get('delete')}
@@ -141,11 +141,12 @@ export default function Fragment({
 			{expand && (
 				<div className="configuration-editor">
 					<AceEditor
+						onChange={(val) => setValue(val)}
 						onRender={({editorElement, editorTextInput}) => {
 							editorElementRef.current = editorElement;
 							editorTextInputRef.current = editorTextInput;
 						}}
-						value={json}
+						value={value}
 					/>
 				</div>
 			)}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/Fragment.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-gsearch-configuration-web/src/main/resources/META-INF/resources/js/components/Fragment.js
@@ -67,17 +67,39 @@ export default function Fragment({
 }) {
 	const [active, setActive] = useState(false);
 	const [expand, setExpand] = useState(true);
-
 	const [value, setValue] = useState(JSON.stringify(json, null, '\t'));
 
 	const editorElementRef = useRef();
 	const editorTextInputRef = useRef();
+	const valueRef = useRef(value);
+
+	useOutsideClick(editorTextInputRef);
 
 	useEffect(() => {
 		if (collapse) {
 			setExpand(false);
 		}
 	}, [collapse]);
+
+	function handleChange(newValue) {
+		valueRef.current = newValue;
+	}
+
+	function useOutsideClick(ref) {
+		useEffect(() => {
+			function handleClickOutside(event) {
+				if (ref.current && !ref.current.contains(event.target)) {
+					setValue(valueRef.current);
+				}
+			}
+
+			document.addEventListener('mousedown', handleClickOutside);
+
+			return () => {
+				document.removeEventListener('mousedown', handleClickOutside);
+			};
+		}, [ref]);
+	}
 
 	return (
 		<div className="configuration-fragment sheet" key={title}>
@@ -141,7 +163,7 @@ export default function Fragment({
 			{expand && (
 				<div className="configuration-editor">
 					<AceEditor
-						onChange={(val) => setValue(val)}
+						onChange={handleChange}
 						onRender={({editorElement, editorTextInput}) => {
 							editorElementRef.current = editorElement;
 							editorTextInputRef.current = editorTextInput;


### PR DESCRIPTION
So the AceEditor was changed to use react hooks, and it now takes in an onChange function and json value as a string. When the user clicks elsewhere from the json editor, the value state would update to whatever is the current ref (this being done inside the Fragment component). So then it saves the changes :D 

I guess next we need to send that new value back up as a json, in correct format. Let me know what you think so far?