### PR TITLE
LPS-130372 boost decay fields

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/blueprint_entry_actions.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/blueprint_entry_actions.jsp
@@ -58,6 +58,16 @@ long companyGroupId = themeDisplay.getCompanyGroupId();
 		/>
 	</c:if>
 
+	<portlet:resourceURL id="<%= BlueprintsAdminMVCCommandNames.EXPORT_BLUEPRINT %>" var="exportEntryURL">
+		<portlet:param name="redirect" value="<%= currentURL %>" />
+		<portlet:param name="<%= BlueprintsAdminWebKeys.BLUEPRINT_ID %>" value="<%= String.valueOf(blueprintId) %>" />
+	</portlet:resourceURL>
+
+	<liferay-ui:icon
+		message="export"
+		url="<%= exportEntryURL %>"
+	/>
+
 	<c:if test="<%= BlueprintsAdminPermission.contains(permissionChecker, companyGroupId, ActionKeys.PERMISSIONS) %>">
 		<liferay-security:permissionsURL
 			modelResource="<%= Blueprint.class.getName() %>"
@@ -76,16 +86,6 @@ long companyGroupId = themeDisplay.getCompanyGroupId();
 			useDialog="<%= true %>"
 		/>
 	</c:if>
-
-	<portlet:resourceURL id="<%= BlueprintsAdminMVCCommandNames.EXPORT_BLUEPRINT %>" var="exportEntryURL">
-		<portlet:param name="redirect" value="<%= currentURL %>" />
-		<portlet:param name="<%= BlueprintsAdminWebKeys.BLUEPRINT_ID %>" value="<%= String.valueOf(blueprintId) %>" />
-	</portlet:resourceURL>
-
-	<liferay-ui:icon
-		message="export"
-		url="<%= exportEntryURL %>"
-	/>
 
 	<c:if test="<%= BlueprintEntryPermission.contains(permissionChecker, blueprint, ActionKeys.DELETE) %>">
 		<portlet:actionURL name="<%= BlueprintsAdminMVCCommandNames.DELETE_BLUEPRINT %>" var="deleteEntryURL">

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/blueprint_entry_search_columns.jspf
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/blueprint_entry_search_columns.jspf
@@ -51,10 +51,6 @@
 
 			<%
 			Date modified = entry.getModifiedDate();
-
-			String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modified.getTime(), true);
-
-			String userName = (themeDisplay.getDefaultUserId() == entry.getUserId()) ? "system" : entry.getUserName();
 			%>
 
 			<h5 class="text-default text-truncate">
@@ -62,7 +58,10 @@
 					<liferay-ui:message arguments="<%= String.valueOf(entry.getBlueprintId()) %>" key="id-x" />
 				</span>
 				<span class="id-text">
-					<liferay-ui:message arguments="<%= new String[] {userName, modifiedDateDescription} %>" key="modified-by-x-x-ago" />
+					<liferay-ui:message arguments='<%= (themeDisplay.getDefaultUserId() == entry.getUserId()) ? "system" : entry.getUserName() %>' key="created-by-x" />
+				</span>
+				<span class="id-text">
+					<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modified.getTime(), true) %>" key="modified-x-ago" />
 				</span>
 			</h5>
 		</liferay-ui:search-container-column-text>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/element_entry_actions.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/element_entry_actions.jsp
@@ -58,6 +58,16 @@ long companyGroupId = themeDisplay.getCompanyGroupId();
 		/>
 	</c:if>
 
+	<portlet:resourceURL id="<%= BlueprintsAdminMVCCommandNames.EXPORT_ELEMENT %>" var="exportEntryURL">
+		<portlet:param name="redirect" value="<%= currentURL %>" />
+		<portlet:param name="<%= BlueprintsAdminWebKeys.ELEMENT_ID %>" value="<%= String.valueOf(elementId) %>" />
+	</portlet:resourceURL>
+
+	<liferay-ui:icon
+		message="export"
+		url="<%= exportEntryURL %>"
+	/>
+
 	<c:if test="<%= BlueprintsAdminPermission.contains(permissionChecker, companyGroupId, ActionKeys.PERMISSIONS) %>">
 		<liferay-security:permissionsURL
 			modelResource="<%= Element.class.getName() %>"
@@ -76,16 +86,6 @@ long companyGroupId = themeDisplay.getCompanyGroupId();
 			useDialog="<%= true %>"
 		/>
 	</c:if>
-
-	<portlet:resourceURL id="<%= BlueprintsAdminMVCCommandNames.EXPORT_ELEMENT %>" var="exportEntryURL">
-		<portlet:param name="redirect" value="<%= currentURL %>" />
-		<portlet:param name="<%= BlueprintsAdminWebKeys.ELEMENT_ID %>" value="<%= String.valueOf(elementId) %>" />
-	</portlet:resourceURL>
-
-	<liferay-ui:icon
-		message="export"
-		url="<%= exportEntryURL %>"
-	/>
 
 	<c:if test="<%= ElementEntryPermission.contains(permissionChecker, element, ActionKeys.DELETE) %>">
 		<portlet:actionURL name="<%= BlueprintsAdminMVCCommandNames.DELETE_ELEMENT %>" var="deleteEntryURL">

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-all-keywords-match.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-all-keywords-match.js
@@ -107,7 +107,10 @@ export default {
 						defaultValue: 10,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-asset-type.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-asset-type.js
@@ -139,7 +139,10 @@ export default {
 						defaultValue: 10,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-commerce-items-for-my-account-groups.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-commerce-items-for-my-account-groups.js
@@ -52,7 +52,10 @@ export default {
 						defaultValue: 10,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category-by-keyword-match.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category-by-keyword-match.js
@@ -72,7 +72,10 @@ export default {
 						defaultValue: 10,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category-for-a-period-of-time.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category-for-a-period-of-time.js
@@ -82,7 +82,10 @@ export default {
 						defaultValue: 10,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category-for-a-user-segment.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category-for-a-user-segment.js
@@ -73,7 +73,10 @@ export default {
 						defaultValue: 20,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category-for-guest-users.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category-for-guest-users.js
@@ -66,7 +66,10 @@ export default {
 						defaultValue: 20,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category-for-new-user-accounts.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category-for-new-user-accounts.js
@@ -81,7 +81,10 @@ export default {
 						defaultValue: 20,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category-for-time-of-day.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category-for-time-of-day.js
@@ -91,7 +91,10 @@ export default {
 						defaultValue: 20,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category.js
@@ -57,7 +57,10 @@ export default {
 						defaultValue: 10,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-on-my-sites.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-on-my-sites.js
@@ -50,7 +50,10 @@ export default {
 						defaultValue: 10,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-with-more-versions.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-with-more-versions.js
@@ -55,7 +55,10 @@ export default {
 						defaultValue: 10,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 					{
 						defaultValue: 1.2,

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-with-user-language-as-the-default-language.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-with-user-language-as-the-default-language.js
@@ -67,7 +67,10 @@ export default {
 						defaultValue: 20,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-freshness.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-freshness.js
@@ -58,11 +58,11 @@ export default {
 						defaultValue: 0.5,
 						label: 'Decay',
 						name: 'decay',
-						type: 'number',
+						type: 'slider',
 						typeOptions: {
 							max: 0.99,
 							min: 0.01,
-							step: 0.1,
+							step: 0.01,
 						},
 					},
 					{
@@ -91,7 +91,10 @@ export default {
 						defaultValue: 2,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-longer-contents.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-longer-contents.js
@@ -57,7 +57,10 @@ export default {
 						defaultValue: 30,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 					{
 						defaultValue: 1.5,

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-proximity.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-proximity.js
@@ -69,11 +69,11 @@ export default {
 						defaultValue: 0.3,
 						label: 'Decay',
 						name: 'decay',
-						type: 'number',
+						type: 'slider',
 						typeOptions: {
 							max: 0.99,
 							min: 0.01,
-							step: 0.1,
+							step: 0.01,
 						},
 					},
 					{
@@ -91,7 +91,10 @@ export default {
 						defaultValue: 2,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-tagged-contents.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-tagged-contents.js
@@ -55,7 +55,10 @@ export default {
 						defaultValue: 5,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-tags-match.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-tags-match.js
@@ -52,7 +52,10 @@ export default {
 						defaultValue: 40,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-web-contents-by-keyword-match.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-web-contents-by-keyword-match.js
@@ -71,7 +71,10 @@ export default {
 						defaultValue: 20,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/search-with-lucene-syntax.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/search-with-lucene-syntax.js
@@ -89,7 +89,10 @@ export default {
 						defaultValue: 1,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/text-match-over-multiple-fields.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/text-match-over-multiple-fields.js
@@ -151,7 +151,10 @@ export default {
 						defaultValue: 1,
 						label: 'Boost',
 						name: 'boost',
-						type: 'slider',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+						},
 					},
 				],
 			},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/ResultListItem.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/ResultListItem.js
@@ -84,10 +84,18 @@ function ResultListItem({item}) {
 
 			<ClayList.ItemField expand>
 				<ClayList.ItemTitle>
-					<ClayLink href={item.b_viewURL} target="_blank">
-						{item.b_title}
-						<ClayIcon className="shortcut-icon" symbol="shortcut" />
-					</ClayLink>
+					{item.b_viewURL ? (
+						<ClayLink href={item.b_viewURL} target="_blank">
+							{item.b_title}
+
+							<ClayIcon
+								className="shortcut-icon"
+								symbol="shortcut"
+							/>
+						</ClayLink>
+					) : (
+						item.b_title
+					)}
 				</ClayList.ItemTitle>
 
 				{RESULTS_DEFAULT_KEYS.map((property) =>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/ResultListItem.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/ResultListItem.js
@@ -31,14 +31,18 @@ const RESULTS_DEFAULT_KEYS = [
 const RESULTS_SHOW_KEYS = ['b_assetEntryId', 'id'];
 
 const blueprintFieldPrefixRegex = new RegExp(`^(${BLUEPRINT_FIELD_PREFIX})`);
-const bracketsRegex = new RegExp(/[[\]]/, 'g');
+const bracketsQuotesRegex = new RegExp(/[[\]"]/, 'g');
 
 function removeBlueprintFieldPrefix(value) {
 	return value.replace(blueprintFieldPrefixRegex, '');
 }
 
 function removeBrackets(value) {
-	return value.replace(bracketsRegex, '');
+	return value.replace(bracketsQuotesRegex, '');
+}
+
+function truncateString(value) {
+	return value.length > 700 ? value.substring(0, 700).concat('...') : value;
 }
 
 function ResultListItem({item}) {
@@ -54,9 +58,11 @@ function ResultListItem({item}) {
 				className={getCN({'text-truncate': collapse})}
 				size={8}
 			>
-				{typeof value === 'object'
-					? removeBrackets(JSON.stringify(value))
-					: value}
+				{truncateString(
+					typeof value === 'object'
+						? removeBrackets(JSON.stringify(value))
+						: value
+				)}
 			</ClayLayout.Col>
 		</ClayLayout.Row>
 	);

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/index.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/index.js
@@ -115,7 +115,7 @@ function EditBlueprintForm({
 									type,
 									typeOptions.required
 								) ||
-								validateBoost(configValue, name, type) ||
+								validateBoost(configValue, type) ||
 								validateNumberRange(
 									configValue,
 									type,

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/index.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/index.js
@@ -385,7 +385,7 @@ function EditBlueprintForm({
 							errors: [
 								{
 									msg: Liferay.Language.get(
-										'the-json-is-invalid'
+										'an-unexpected-error-occurred'
 									),
 									severity: Liferay.Language.get('error'),
 								},

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/utils/validation.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/utils/validation.js
@@ -13,11 +13,7 @@ import {ERROR_MESSAGES} from './errorMessages';
 import {INPUT_TYPES} from './inputTypes';
 import {isDefined, sub} from './utils';
 
-export const validateBoost = (configValue, name, type) => {
-	if (name == 'boost' && configValue < 0) {
-		return ERROR_MESSAGES.NEGATIVE_BOOST;
-	}
-
+export const validateBoost = (configValue, type) => {
 	if (type === INPUT_TYPES.FIELD_MAPPING && configValue.boost < 0) {
 		return ERROR_MESSAGES.NEGATIVE_BOOST;
 	}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/content/Language.properties
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/content/Language.properties
@@ -92,7 +92,6 @@ sort-configuration=Sort Configuration
 sorts=Sorts
 the-configuration-has-missing-or-invalid-values=The configuration has missing or invalid values.
 the-following-configuration-key-is-missing-x=The following configuration key(s) is missing: {0}
-the-json-is-invalid=The JSON is invalid
 there-are-no-match-clauses-in-your-configuration=There are no match clauses in your configuration. A search will always produce the same result set.
 ui-configuration-json=UI Configuration (JSON)
 ui-configuration-json-helptext=Configuration for how the fields will be displayed in the query builder.

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/test/js/utils/validation.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/test/js/utils/validation.js
@@ -20,18 +20,6 @@ import {
 
 describe('validation', () => {
 	describe('validateBoost', () => {
-		it('returns error message for negative number', () => {
-			expect(validateBoost(-1, 'boost', INPUT_TYPES.NUMBER)).toEqual(
-				ERROR_MESSAGES.NEGATIVE_BOOST
-			);
-		});
-
-		it('returns error message for negative value in slider', () => {
-			expect(validateBoost(-1, 'boost', INPUT_TYPES.SLIDER)).toEqual(
-				ERROR_MESSAGES.NEGATIVE_BOOST
-			);
-		});
-
 		it('returns error message for negative value in field mapping', () => {
 			expect(
 				validateBoost(
@@ -40,7 +28,6 @@ describe('validation', () => {
 						field: 'localized_title',
 						locale: '${context.language_id}',
 					},
-					'field',
 					INPUT_TYPES.FIELD_MAPPING
 				)
 			).toEqual(ERROR_MESSAGES.NEGATIVE_BOOST);
@@ -61,28 +48,9 @@ describe('validation', () => {
 							locale: '${context.language_id}',
 						},
 					],
-					'fields',
 					INPUT_TYPES.FIELD_MAPPING_LIST
 				)
 			).toEqual(ERROR_MESSAGES.NEGATIVE_BOOST);
-		});
-
-		it('returns undefined for zero boost', () => {
-			expect(
-				validateBoost(0, 'boost', INPUT_TYPES.NUMBER)
-			).toBeUndefined();
-		});
-
-		it('returns undefined for positive boost', () => {
-			expect(
-				validateBoost(1, 'boost', INPUT_TYPES.NUMBER)
-			).toBeUndefined();
-		});
-
-		it('returns undefined for non-boost name', () => {
-			expect(
-				validateBoost(-1, 'notBoost', INPUT_TYPES.NUMBER)
-			).toBeUndefined();
 		});
 
 		it('returns undefined for non-negative boost in field mapping', () => {
@@ -93,7 +61,6 @@ describe('validation', () => {
 						field: 'localized_title',
 						locale: '${context.language_id}',
 					},
-					'field',
 					INPUT_TYPES.FIELD_MAPPING
 				)
 			).toBeUndefined();
@@ -114,7 +81,6 @@ describe('validation', () => {
 							locale: '${context.language_id}',
 						},
 					],
-					'field',
 					INPUT_TYPES.FIELD_MAPPING
 				)
 			).toBeUndefined();
@@ -127,7 +93,6 @@ describe('validation', () => {
 						field: 'localized_title',
 						locale: '${context.language_id}',
 					},
-					'field',
 					INPUT_TYPES.FIELD_MAPPING
 				)
 			).toBeUndefined();
@@ -146,7 +111,6 @@ describe('validation', () => {
 							locale: '${context.language_id}',
 						},
 					],
-					'field',
 					INPUT_TYPES.FIELD_MAPPING
 				)
 			).toBeUndefined();

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/blueprints/blade_sample.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/blueprints/blade_sample.json
@@ -878,7 +878,10 @@
 										"defaultValue": 1,
 										"label": "Boost",
 										"name": "boost",
-										"type": "slider"
+										"type": "number",
+										"typeOptions": {
+											"min": 0
+										}
 									}
 								]
 							}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/blueprints/content_driven.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/blueprints/content_driven.json
@@ -954,7 +954,10 @@
 										"defaultValue": 1,
 										"label": "Boost",
 										"name": "boost",
-										"type": "slider"
+										"type": "number",
+										"typeOptions": {
+											"min": 0
+										}
 									}
 								]
 							}
@@ -1101,7 +1104,10 @@
 										"defaultValue": 1,
 										"label": "Boost",
 										"name": "boost",
-										"type": "slider"
+										"type": "number",
+										"typeOptions": {
+											"min": 0
+										}
 									}
 								]
 							}
@@ -1233,7 +1239,10 @@
 										"defaultValue": 20,
 										"label": "Boost",
 										"name": "boost",
-										"type": "slider"
+										"type": "number",
+										"typeOptions": {
+											"min": 0
+										}
 									}
 								]
 							}
@@ -1318,7 +1327,10 @@
 										"defaultValue": 10,
 										"label": "Boost",
 										"name": "boost",
-										"type": "slider"
+										"type": "number",
+										"typeOptions": {
+											"min": 0
+										}
 									},
 									{
 										"defaultValue": 1.2,
@@ -1464,7 +1476,10 @@
 										"defaultValue": 30,
 										"label": "Boost",
 										"name": "boost",
-										"type": "slider"
+										"type": "number",
+										"typeOptions": {
+											"min": 0
+										}
 									},
 									{
 										"defaultValue": 1.5,
@@ -1614,11 +1629,11 @@
 										"defaultValue": 0.5,
 										"label": "Decay",
 										"name": "decay",
-										"type": "number",
+										"type": "slider",
 										"typeOptions": {
 											"max": 0.99,
 											"min": 0.01,
-											"step": 0.1
+											"step": 0.01
 										}
 									},
 									{
@@ -1647,7 +1662,10 @@
 										"defaultValue": 2,
 										"label": "Boost",
 										"name": "boost",
-										"type": "slider"
+										"type": "number",
+										"typeOptions": {
+											"min": 0
+										}
 									}
 								]
 							}
@@ -1729,7 +1747,10 @@
 										"defaultValue": 40,
 										"label": "Boost",
 										"name": "boost",
-										"type": "slider"
+										"type": "number",
+										"typeOptions": {
+											"min": 0
+										}
 									}
 								]
 							}
@@ -1869,7 +1890,10 @@
 										"defaultValue": 10,
 										"label": "Boost",
 										"name": "boost",
-										"type": "slider"
+										"type": "number",
+										"typeOptions": {
+											"min": 0
+										}
 									}
 								]
 							}
@@ -2034,7 +2058,10 @@
 										"defaultValue": 10,
 										"label": "Boost",
 										"name": "boost",
-										"type": "slider"
+										"type": "number",
+										"typeOptions": {
+											"min": 0
+										}
 									}
 								]
 							}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/blueprints/personalization.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/blueprints/personalization.json
@@ -233,11 +233,11 @@
 										"defaultValue": 0.3,
 										"label": "Decay",
 										"name": "decay",
-										"type": "number",
+										"type": "slider",
 										"typeOptions": {
 											"max": 0.99,
 											"min": 0.01,
-											"step": 0.1
+											"step": 0.01
 										}
 									},
 									{
@@ -255,7 +255,10 @@
 										"defaultValue": 2,
 										"label": "Boost",
 										"name": "boost",
-										"type": "slider"
+										"type": "number",
+										"typeOptions": {
+											"min": 0
+										}
 									}
 								]
 							}
@@ -365,7 +368,10 @@
 										"defaultValue": 20,
 										"label": "Boost",
 										"name": "boost",
-										"type": "slider"
+										"type": "number",
+										"typeOptions": {
+											"min": 0
+										}
 									}
 								]
 							}
@@ -440,7 +446,10 @@
 										"defaultValue": 10,
 										"label": "Boost",
 										"name": "boost",
-										"type": "slider"
+										"type": "number",
+										"typeOptions": {
+											"min": 0
+										}
 									}
 								]
 							}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_all_keywords_match.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_all_keywords_match.json
@@ -94,7 +94,10 @@
 								"defaultValue": 10,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_asset_type.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_asset_type.json
@@ -112,7 +112,10 @@
 								"defaultValue": 10,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_for_the_current_language.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_for_the_current_language.json
@@ -53,7 +53,10 @@
 								"defaultValue": 20,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category.json
@@ -43,7 +43,10 @@
 								"defaultValue": 10,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category_by_keyword_match.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category_by_keyword_match.json
@@ -57,7 +57,10 @@
 								"defaultValue": 10,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category_for_a_period_of_time.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category_for_a_period_of_time.json
@@ -68,7 +68,10 @@
 								"defaultValue": 10,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category_for_a_user_segment.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category_for_a_user_segment.json
@@ -60,7 +60,10 @@
 								"defaultValue": 20,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category_for_guest_users.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category_for_guest_users.json
@@ -52,7 +52,10 @@
 								"defaultValue": 20,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category_for_new_user_accounts.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category_for_new_user_accounts.json
@@ -66,7 +66,10 @@
 								"defaultValue": 20,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category_for_the_time_of_day.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category_for_the_time_of_day.json
@@ -77,7 +77,10 @@
 								"defaultValue": 20,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_on_my_sites.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_on_my_sites.json
@@ -37,7 +37,10 @@
 								"defaultValue": 10,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_with_more_versions.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_with_more_versions.json
@@ -42,7 +42,10 @@
 								"defaultValue": 10,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							},
 							{
 								"defaultValue": 1.2,

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_freshness.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_freshness.json
@@ -44,11 +44,11 @@
 								"defaultValue": 0.5,
 								"label": "Decay",
 								"name": "decay",
-								"type": "number",
+								"type": "slider",
 								"typeOptions": {
 									"max": 0.99,
 									"min": 0.01,
-									"step": 0.1
+									"step": 0.01
 								}
 							},
 							{
@@ -77,7 +77,10 @@
 								"defaultValue": 2,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_items_for_my_commerce_account_groups.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_items_for_my_commerce_account_groups.json
@@ -37,7 +37,10 @@
 								"defaultValue": 10,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_longer_contents.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_longer_contents.json
@@ -42,7 +42,10 @@
 								"defaultValue": 30,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							},
 							{
 								"defaultValue": 1.5,

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_proximity.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_proximity.json
@@ -54,7 +54,7 @@
 								"defaultValue": 0.3,
 								"label": "Decay",
 								"name": "decay",
-								"type": "number",
+								"type": "slider",
 								"typeOptions": {
 									"max": 0.99,
 									"min": 0.01,
@@ -76,7 +76,10 @@
 								"defaultValue": 2,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_tagged_contents.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_tagged_contents.json
@@ -42,7 +42,10 @@
 								"defaultValue": 5,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_tags_match.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_tags_match.json
@@ -39,7 +39,10 @@
 								"defaultValue": 40,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_web_contents_by_keyword_match.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_web_contents_by_keyword_match.json
@@ -55,7 +55,10 @@
 								"defaultValue": 20,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/search_with_the_lucene_syntax.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/search_with_the_lucene_syntax.json
@@ -76,7 +76,10 @@
 								"defaultValue": 1,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/text_match_over_multiple_fields.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/text_match_over_multiple_fields.json
@@ -138,7 +138,10 @@
 								"defaultValue": 1,
 								"label": "Boost",
 								"name": "boost",
-								"type": "slider"
+								"type": "number",
+								"typeOptions": {
+									"min": 0
+								}
 							}
 						]
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-searchresponse-json-translator-impl/src/main/java/com/liferay/portal/search/tuning/blueprints/searchresponse/json/translator/internal/result/builder/BaseResultBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-searchresponse-json-translator-impl/src/main/java/com/liferay/portal/search/tuning/blueprints/searchresponse/json/translator/internal/result/builder/BaseResultBuilder.java
@@ -257,8 +257,8 @@ public abstract class BaseResultBuilder implements ResultBuilder {
 			if (!Validator.isBlank(modified)) {
 				Date lastModified = INDEX_DATE_FORMAT.parse(modified);
 
-				DateFormat dateFormat = DateFormat.getDateInstance(
-					DateFormat.SHORT, locale);
+				DateFormat dateFormat = DateFormat.getDateTimeInstance(
+					DateFormat.SHORT, DateFormat.SHORT, locale);
 
 				dateString = dateFormat.format(lastModified);
 			}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-130372
https://issues.liferay.com/browse/LPS-130390

Here're the changes, let me know what you think!
- All boosts changed to 'numbers' on resource + admin-web
- All decays changed to 'sliders' with a step of 0.01
- Rearrange order of actions in the blueprints view
- Update the wording in the blueprints view