### PR TITLE
LPS-130992 'Text Match Over Multiple Fields' invalid combinations

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/css/_code_mirror.scss
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/css/_code_mirror.scss
@@ -1,4 +1,8 @@
 .codemirror-editor-wrapper {
 	border: 1px solid $mainLighten74;
 	border-radius: 4px;
+
+	.cm-s-default {
+		font-size: 13px;
+	}
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/css/_edit_element.scss
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/css/_edit_element.scss
@@ -106,7 +106,6 @@ $elementHeaderHeight: 48px;
 			width: 100%;
 
 			.cm-s-default {
-				font-size: 13px; // Keeps the same font-size across browsers
 				height: 100%;
 			}
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/css/_element.scss
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/css/_element.scss
@@ -151,19 +151,6 @@
 				}
 			}
 
-			.custom-json {
-				&.disabled {
-					.codemirror-editor-wrapper {
-						border-color: $lightBackground;
-
-						.CodeMirror-line,
-						.cm-string {
-							color: #a7a9bc;
-						}
-					}
-				}
-			}
-
 			.date-picker-input {
 				display: flex;
 
@@ -198,6 +185,20 @@
 
 			.slider-configuration {
 				padding: 10px;
+			}
+		}
+	}
+
+	.custom-json {
+		&.disabled {
+			.codemirror-editor-wrapper {
+				border-color: $lightBackground;
+
+				.cm-atom,
+				.cm-string,
+				.CodeMirror-line {
+					color: #a7a9bc;
+				}
 			}
 		}
 	}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/css/_element.scss
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/css/_element.scss
@@ -122,6 +122,13 @@
 				}
 			}
 
+			.custom-checkbox {
+				.custom-control-label {
+					font-size: 12px;
+					line-height: 26px;
+				}
+			}
+
 			.list-item-label {
 				padding-left: 0;
 				width: 30%;

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/css/_result_list_item.scss
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/css/_result_list_item.scss
@@ -4,6 +4,16 @@
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
 
+	.list-group-header {
+		background-color: unset;
+		border-left: 0;
+		border-right: 0;
+		border-top: 0;
+		font-size: 11px;
+		padding-left: 0;
+		padding-top: 12px;
+	}
+
 	.row.justify-content-start {
 		padding: 0 12px;
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category-for-a-period-of-time.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/boost-contents-in-a-category-for-a-period-of-time.js
@@ -68,16 +68,20 @@ export default {
 						type: 'number',
 					},
 					{
-						format: 'YYYYMMDD',
 						label: 'Create Date: From',
 						name: 'start_date',
 						type: 'date',
+						typeOptions: {
+							format: 'YYYYMMDD',
+						},
 					},
 					{
-						format: 'YYYYMMDD',
 						label: 'Create Date: To',
 						name: 'end_date',
 						type: 'date',
+						typeOptions: {
+							format: 'YYYYMMDD',
+						},
 					},
 					{
 						defaultValue: 10,

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/text-match-over-multiple-fields.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/elements/text-match-over-multiple-fields.js
@@ -28,8 +28,11 @@ export default {
 								boost: '${configuration.boost}',
 								fields: '${configuration.fields}',
 								fuzziness: '${configuration.fuzziness}',
+								minimum_should_match:
+									'${configuration.minimum_should_match}',
 								operator: '${configuration.operator}',
 								query: '${keywords}',
+								slop: '${configuration.slop}',
 								type: '${configuration.type}',
 							},
 						},
@@ -124,10 +127,14 @@ export default {
 						},
 					},
 					{
+						defaultValue: 'AUTO',
+						helpText:
+							'Only use fuzziness with the following match types: most fields, best fields, bool prefix.',
 						label: 'Fuzziness',
 						name: 'fuzziness',
 						type: 'select',
 						typeOptions: {
+							nullable: true,
 							options: [
 								{
 									label: 'Auto',
@@ -155,6 +162,28 @@ export default {
 						type: 'number',
 						typeOptions: {
 							min: 0,
+						},
+					},
+					{
+						defaultValue: '1',
+						label: 'Minimum Should Match',
+						name: 'minimum_should_match',
+						type: 'text',
+						typeOptions: {
+							nullable: true,
+						},
+					},
+					{
+						defaultValue: null,
+						helpText:
+							'Only use slop with the following match types: phrase, phrase prefix.',
+						label: 'Slop',
+						name: 'slop',
+						type: 'number',
+						typeOptions: {
+							min: 0,
+							nullable: true,
+							step: 1,
 						},
 					},
 				],

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/PreviewSidebar.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/PreviewSidebar.js
@@ -148,6 +148,7 @@ function PreviewSidebar({
 						body={
 							<div className="json-modal">
 								<CodeMirrorEditor
+									folded
 									readOnly
 									value={JSON.stringify(results, null, 2)}
 								/>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/ResultListItem.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/ResultListItem.js
@@ -117,6 +117,12 @@ function ResultListItem({item}) {
 							_renderListRow(property, item[property])
 						)}
 
+						<div className="list-group-header">
+							<span className="list-group-header-title">
+								{Liferay.Language.get('document-fields')}
+							</span>
+						</div>
+
 						{Object.keys(item.document)
 							.sort()
 							.map((property) =>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/index.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/index.js
@@ -547,6 +547,9 @@ function EditBlueprintForm({
 								errors={formik.errors.selectedQueryElements}
 								frameworkConfig={formik.values.frameworkConfig}
 								indexFields={indexFields}
+								isSubmitting={
+									formik.isSubmitting || previewInfo.loading
+								}
 								onBlur={formik.handleBlur}
 								onChange={formik.handleChange}
 								onDeleteElement={_handleDeleteElement}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/index.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/index.js
@@ -237,7 +237,7 @@ function EditBlueprintForm({
 
 				const configErrors = {};
 
-				if (uiConfigurationJSON && uiConfigurationJSON.fieldSets) {
+				if (Array.isArray(uiConfigurationJSON?.fieldSets)) {
 					uiConfigurationJSON.fieldSets.map(({fields = []}) => {
 						fields.map(({name, type, typeOptions = {}}) => {
 							const configValue = uiConfigurationValues[name];
@@ -264,7 +264,7 @@ function EditBlueprintForm({
 				}
 				else if (!uiConfigurationJSON) {
 					const configValue =
-						uiConfigurationValues.elementTemplateJSON;
+						uiConfigurationValues?.elementTemplateJSON;
 
 					const configError =
 						validateRequired(configValue, INPUT_TYPES.JSON) ||
@@ -355,7 +355,7 @@ function EditBlueprintForm({
 	});
 
 	const _handleAddElement = (element) => {
-		if (formik.touched && formik.touched.selectedQueryElements) {
+		if (formik.touched?.selectedQueryElements) {
 			formik.setTouched({
 				...formik.touched,
 				selectedQueryElements: [
@@ -382,7 +382,7 @@ function EditBlueprintForm({
 			(item) => item.id == id
 		);
 
-		if (formik.touched && formik.touched.selectedQueryElements) {
+		if (formik.touched?.selectedQueryElements) {
 			formik.setTouched({
 				...formik.touched,
 				selectedQueryElements: formik.touched.selectedQueryElements.filter(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/index.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/index.js
@@ -87,6 +87,23 @@ function EditBlueprintForm({
 	);
 
 	/**
+	 * Abstracts title and description from the existing form, as
+	 * query builder has several inputs that should not be included in
+	 * submission.
+	 * @param {FormData} formData
+	 */
+	const _appendTitleAndDescription = (formData) => {
+		for (const pair of new FormData(form.current).entries()) {
+			if (
+				pair[0].includes(`${namespace}title`) ||
+				pair[0].includes(`${namespace}description`)
+			) {
+				formData.append(pair[0], pair[1]);
+			}
+		}
+	};
+
+	/**
 	 * Formats the form values for the "configuration" parameter to send to
 	 * the server. Sets defaults so the JSON.parse calls don't break.
 	 * @param {Object} values Form values
@@ -123,7 +140,9 @@ function EditBlueprintForm({
 	};
 
 	const _handleFormikSubmit = (values) => {
-		const formData = new FormData(form.current);
+		const formData = new FormData();
+
+		_appendTitleAndDescription(formData);
 
 		try {
 			formData.append(
@@ -388,7 +407,9 @@ function EditBlueprintForm({
 			loading: true,
 		}));
 
-		const formData = new FormData(form.current);
+		const formData = new FormData();
+
+		_appendTitleAndDescription(formData);
 
 		try {
 			formData.append(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/tabs/QueryBuilder.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/tabs/QueryBuilder.js
@@ -82,10 +82,7 @@ function QueryBuilder({
 			const elementOutput = getElementOutput(element);
 
 			return (
-				elementOutput.clauses &&
-				elementOutput.clauses[0] &&
-				elementOutput.clauses[0].occur &&
-				elementOutput.clauses[0].occur === 'must' &&
+				elementOutput.clauses?.[0]?.occur === 'must' &&
 				elementOutput.enabled
 			);
 		});

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/tabs/QueryBuilder.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/edit_blueprint/tabs/QueryBuilder.js
@@ -61,6 +61,7 @@ function QueryBuilder({
 	errors = [],
 	frameworkConfig,
 	indexFields,
+	isSubmitting,
 	onBlur,
 	onChange,
 	onDeleteElement,
@@ -113,6 +114,7 @@ function QueryBuilder({
 							id={element.id}
 							index={index}
 							indexFields={indexFields}
+							isSubmitting={isSubmitting}
 							key={element.id}
 							onBlur={onBlur}
 							onChange={onChange}
@@ -133,6 +135,7 @@ function QueryBuilder({
 							error={errors[index]}
 							id={element.id}
 							index={index}
+							isSubmitting={isSubmitting}
 							key={element.id}
 							onDeleteElement={onDeleteElement}
 							prefixedId={`${ELEMENT_PREFIX.QUERY}-${index}`}
@@ -312,6 +315,7 @@ QueryBuilder.propTypes = {
 	errors: PropTypes.arrayOf(PropTypes.object),
 	frameworkConfig: PropTypes.object,
 	indexFields: PropTypes.arrayOf(PropTypes.object),
+	isSubmitting: PropTypes.bool,
 	onBlur: PropTypes.func,
 	onChange: PropTypes.func,
 	onDeleteElement: PropTypes.func,

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/CodeMirrorEditor.js
@@ -70,7 +70,13 @@ function useCombinedRefs(...refs) {
 
 const CodeMirrorEditor = React.forwardRef(
 	(
-		{onChange = () => {}, mode = 'json', value = '', readOnly = false},
+		{
+			folded = false,
+			onChange = () => {},
+			mode = 'json',
+			value = '',
+			readOnly = false,
+		},
 		ref
 	) => {
 		const innerRef = useRef(ref);
@@ -99,12 +105,23 @@ const CodeMirrorEditor = React.forwardRef(
 					readOnly,
 					tabSize: 2,
 					value,
-					viewportMargin: Infinity,
 				});
 
 				codeMirror.on('change', (cm) => {
 					onChange(cm.getValue());
 				});
+
+				if (folded) {
+					codeMirror.operation(() => {
+						for (
+							let line = codeMirror.firstLine() + 1;
+							line <= codeMirror.lastLine() - 1;
+							++line
+						) {
+							codeMirror.foldCode({ch: 0, line}, null, 'fold');
+						}
+					});
+				}
 
 				editor.current = codeMirror;
 			}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/JSONElement.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/JSONElement.js
@@ -28,6 +28,7 @@ function JSONElement({
 	error = {},
 	id,
 	index,
+	isSubmitting,
 	onDeleteElement,
 	prefixedId,
 	setFieldTouched,
@@ -136,6 +137,7 @@ function JSONElement({
 					})}
 				>
 					<JSONInput
+						disabled={isSubmitting}
 						name={_inputName(index)}
 						setFieldTouched={setFieldTouched}
 						setFieldValue={setFieldValue}
@@ -168,6 +170,7 @@ JSONElement.propTypes = {
 	error: PropTypes.object,
 	id: PropTypes.number,
 	index: PropTypes.number,
+	isSubmitting: PropTypes.bool,
 	onDeleteElement: PropTypes.func,
 	prefixedId: PropTypes.string,
 	setFieldTouched: PropTypes.func,

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/DateInput.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/DateInput.js
@@ -16,40 +16,62 @@ import ClayIcon from '@clayui/icon';
 import moment from 'moment';
 import React from 'react';
 
-function DateInput({disabled, name, setFieldTouched, setFieldValue, value}) {
-	return (
-		<div className="date-picker-input" onBlur={() => setFieldTouched(name)}>
-			<ClayDatePicker
-				dateFormat="MM/dd/yyyy"
-				disabled={disabled}
-				onValueChange={(value) => {
-					setFieldValue(name, moment(value).unix());
-				}}
-				placeholder="MM/DD/YYYY"
-				readOnly
-				sizing="sm"
-				value={value ? moment.unix(value).format('MM/DD/YYYY') : ''}
-				years={{
-					end: 2024,
-					start: 1997,
-				}}
-			/>
+import NullableCheckbox from './NullableCheckbox';
 
-			{!!value && (
-				<ClayInput.GroupItem shrink>
-					<ClayButton
-						aria-label={Liferay.Language.get('delete')}
-						disabled={disabled}
-						displayType="unstyled"
-						monospaced
-						onClick={() => setFieldValue(name, '')}
-						small
-					>
-						<ClayIcon symbol="times-circle" />
-					</ClayButton>
-				</ClayInput.GroupItem>
+function DateInput({
+	disabled,
+	name,
+	nullable,
+	setFieldTouched,
+	setFieldValue,
+	value,
+}) {
+	return (
+		<>
+			<div
+				className="date-picker-input"
+				onBlur={() => setFieldTouched(name)}
+			>
+				<ClayDatePicker
+					dateFormat="MM/dd/yyyy"
+					disabled={disabled || value === null}
+					onValueChange={(value) => {
+						setFieldValue(name, moment(value, 'MM/DD/YYYY').unix());
+					}}
+					placeholder="MM/DD/YYYY"
+					readOnly
+					sizing="sm"
+					value={value ? moment.unix(value).format('MM/DD/YYYY') : ''}
+					years={{
+						end: 2024,
+						start: 1997,
+					}}
+				/>
+
+				{!!value && (
+					<ClayInput.GroupItem shrink>
+						<ClayButton
+							aria-label={Liferay.Language.get('delete')}
+							disabled={disabled || value === null}
+							displayType="unstyled"
+							monospaced
+							onClick={() => setFieldValue(name, '')}
+							small
+						>
+							<ClayIcon symbol="times-circle" />
+						</ClayButton>
+					</ClayInput.GroupItem>
+				)}
+			</div>
+
+			{nullable && (
+				<NullableCheckbox
+					disabled={disabled}
+					onChange={(val) => setFieldValue(name, val)}
+					value={value}
+				/>
 			)}
-		</div>
+		</>
 	);
 }
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/FieldInput.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/FieldInput.js
@@ -37,13 +37,13 @@ function FieldInput({
 		<>
 			<div className="single-field">
 				<FieldRow
-					boost={value ? value.boost : 1}
+					boost={value?.boost || 1}
 					disabled={disabled || value === null}
-					field={value ? value.field : ''}
+					field={value?.field || ''}
 					id={id}
 					indexFields={indexFields}
-					languageIdPosition={value ? value.languageIdPosition : -1}
-					locale={value ? value.locale : ''}
+					languageIdPosition={value?.languageIdPosition || -1}
+					locale={value?.locale || ''}
 					onBlur={_handleBlur}
 					onChange={_handleChange}
 					showBoost={showBoost}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/FieldInput.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/FieldInput.js
@@ -12,12 +12,14 @@
 import React from 'react';
 
 import FieldRow from './FieldRow';
+import NullableCheckbox from './NullableCheckbox';
 
 function FieldInput({
 	disabled,
 	id,
 	indexFields,
 	name,
+	nullable,
 	setFieldTouched,
 	setFieldValue,
 	showBoost,
@@ -32,20 +34,34 @@ function FieldInput({
 	};
 
 	return (
-		<div className="single-field">
-			<FieldRow
-				boost={value.boost}
-				disabled={disabled}
-				field={value.field}
-				id={id}
-				indexFields={indexFields}
-				languageIdPosition={value.languageIdPosition}
-				locale={value.locale}
-				onBlur={_handleBlur}
-				onChange={_handleChange}
-				showBoost={showBoost}
-			/>
-		</div>
+		<>
+			<div className="single-field">
+				<FieldRow
+					boost={value ? value.boost : 1}
+					disabled={disabled || value === null}
+					field={value ? value.field : ''}
+					id={id}
+					indexFields={indexFields}
+					languageIdPosition={value ? value.languageIdPosition : -1}
+					locale={value ? value.locale : ''}
+					onBlur={_handleBlur}
+					onChange={_handleChange}
+					showBoost={showBoost}
+				/>
+			</div>
+
+			{nullable && (
+				<NullableCheckbox
+					defaultValue={{
+						field: '',
+						locale: '',
+					}}
+					disabled={disabled}
+					onChange={(val) => setFieldValue(name, val)}
+					value={value}
+				/>
+			)}
+		</>
 	);
 }
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/FieldListInput.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/FieldListInput.js
@@ -15,12 +15,14 @@ import ClayIcon from '@clayui/icon';
 import React from 'react';
 
 import FieldRow from './FieldRow';
+import NullableCheckbox from './NullableCheckbox';
 
 function FieldListInput({
 	disabled,
 	id,
 	indexFields,
 	name,
+	nullable,
 	setFieldTouched,
 	setFieldValue,
 	showBoost,
@@ -46,40 +48,52 @@ function FieldListInput({
 	};
 
 	return (
-		<div className="field">
-			{value.map((item, index) => (
-				<FieldRow
-					boost={item.boost}
-					disabled={disabled}
-					field={item.field}
-					id={`${id}_${index}`}
-					index={index}
-					indexFields={indexFields}
-					key={index}
-					languageIdPosition={item.languageIdPosition}
-					locale={item.locale}
-					onBlur={_handleBlur}
-					onChange={_handleChange(index)}
-					onDelete={_handleFieldRowDelete(index)}
-					showBoost={showBoost}
-				/>
-			))}
+		<>
+			<div className="field">
+				{value &&
+					value.map((item, index) => (
+						<FieldRow
+							boost={item.boost}
+							disabled={disabled || value === null}
+							field={item.field}
+							id={`${id}_${index}`}
+							index={index}
+							indexFields={indexFields}
+							key={index}
+							languageIdPosition={item.languageIdPosition}
+							locale={item.locale}
+							onBlur={_handleBlur}
+							onChange={_handleChange(index)}
+							onDelete={_handleFieldRowDelete(index)}
+							showBoost={showBoost}
+						/>
+					))}
 
-			<ClayForm.Group className="add-remove-field">
-				<ClayButton.Group spaced>
-					<ClayButton
-						aria-label={Liferay.Language.get('add-field')}
-						disabled={disabled}
-						displayType="secondary"
-						monospaced
-						onClick={_handleFieldRowAdd}
-						small
-					>
-						<ClayIcon symbol="plus" />
-					</ClayButton>
-				</ClayButton.Group>
-			</ClayForm.Group>
-		</div>
+				<ClayForm.Group className="add-remove-field">
+					<ClayButton.Group spaced>
+						<ClayButton
+							aria-label={Liferay.Language.get('add-field')}
+							disabled={disabled || value === null}
+							displayType="secondary"
+							monospaced
+							onClick={_handleFieldRowAdd}
+							small
+						>
+							<ClayIcon symbol="plus" />
+						</ClayButton>
+					</ClayButton.Group>
+				</ClayForm.Group>
+			</div>
+
+			{nullable && (
+				<NullableCheckbox
+					defaultValue={[]}
+					disabled={disabled}
+					onChange={(val) => setFieldValue(name, val)}
+					value={value}
+				/>
+			)}
+		</>
 	);
 }
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/FieldListInput.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/FieldListInput.js
@@ -50,24 +50,23 @@ function FieldListInput({
 	return (
 		<>
 			<div className="field">
-				{value &&
-					value.map((item, index) => (
-						<FieldRow
-							boost={item.boost}
-							disabled={disabled || value === null}
-							field={item.field}
-							id={`${id}_${index}`}
-							index={index}
-							indexFields={indexFields}
-							key={index}
-							languageIdPosition={item.languageIdPosition}
-							locale={item.locale}
-							onBlur={_handleBlur}
-							onChange={_handleChange(index)}
-							onDelete={_handleFieldRowDelete(index)}
-							showBoost={showBoost}
-						/>
-					))}
+				{value?.map((item, index) => (
+					<FieldRow
+						boost={item.boost}
+						disabled={disabled || value === null}
+						field={item.field}
+						id={`${id}_${index}`}
+						index={index}
+						indexFields={indexFields}
+						key={index}
+						languageIdPosition={item.languageIdPosition}
+						locale={item.locale}
+						onBlur={_handleBlur}
+						onChange={_handleChange(index)}
+						onDelete={_handleFieldRowDelete(index)}
+						showBoost={showBoost}
+					/>
+				))}
 
 				<ClayForm.Group className="add-remove-field">
 					<ClayButton.Group spaced>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/ItemSelectorInput.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/ItemSelectorInput.js
@@ -15,12 +15,15 @@ import ClayIcon from '@clayui/icon';
 import {openSelectionModal} from 'frontend-js-web';
 import React from 'react';
 
+import NullableCheckbox from './NullableCheckbox';
+
 function ItemSelectorInput({
 	disabled,
 	entityJSON,
 	itemType,
 	label,
 	name,
+	nullable,
 	setFieldTouched,
 	setFieldValue,
 	value,
@@ -65,52 +68,63 @@ function ItemSelectorInput({
 	};
 
 	return (
-		<ClayInput.Group onBlur={() => setFieldTouched(name)} small>
-			<ClayInput.GroupItem>
-				<ClayInput
-					aria-label={label}
-					disabled={disabled}
-					name={name}
-					readOnly
-					type="text"
-					value={
-						value.length > 0
-							? value.map((item) => item.label).join(', ')
-							: ''
-					}
-				/>
-			</ClayInput.GroupItem>
+		<>
+			<ClayInput.Group onBlur={() => setFieldTouched(name)} small>
+				<ClayInput.GroupItem>
+					<ClayInput
+						aria-label={label}
+						disabled={disabled || value === null}
+						name={name}
+						readOnly
+						type="text"
+						value={
+							value && value.length > 0
+								? value.map((item) => item.label).join(', ')
+								: ''
+						}
+					/>
+				</ClayInput.GroupItem>
 
-			{value.length > 0 && (
+				{value && value.length > 0 && (
+					<ClayInput.GroupItem shrink>
+						<ClayButton
+							aria-label={Liferay.Language.get('delete')}
+							className="component-action"
+							disabled={disabled || value === null}
+							displayType="unstyled"
+							onClick={() => setFieldValue(name, [])}
+						>
+							<ClayIcon symbol="times-circle" />
+						</ClayButton>
+					</ClayInput.GroupItem>
+				)}
+
 				<ClayInput.GroupItem shrink>
 					<ClayButton
-						aria-label={Liferay.Language.get('delete')}
-						className="component-action"
-						disabled={disabled}
-						displayType="unstyled"
-						onClick={() => setFieldValue(name, [])}
+						aria-label={Liferay.Language.get('select')}
+						disabled={disabled || !entityJSON || value === null}
+						displayType="secondary"
+						onClick={() => {
+							if (entityJSON) {
+								_handleMultipleEntitySelect(itemType);
+							}
+						}}
+						small
 					>
-						<ClayIcon symbol="times-circle" />
+						{Liferay.Language.get('select')}
 					</ClayButton>
 				</ClayInput.GroupItem>
-			)}
+			</ClayInput.Group>
 
-			<ClayInput.GroupItem shrink>
-				<ClayButton
-					aria-label={Liferay.Language.get('select')}
-					disabled={disabled || !entityJSON}
-					displayType="secondary"
-					onClick={() => {
-						if (entityJSON) {
-							_handleMultipleEntitySelect(itemType);
-						}
-					}}
-					small
-				>
-					{Liferay.Language.get('select')}
-				</ClayButton>
-			</ClayInput.GroupItem>
-		</ClayInput.Group>
+			{nullable && (
+				<NullableCheckbox
+					defaultValue={[]}
+					disabled={disabled}
+					onChange={(val) => setFieldValue(name, val)}
+					value={value}
+				/>
+			)}
+		</>
 	);
 }
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/JSONInput.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/JSONInput.js
@@ -13,12 +13,14 @@ import getCN from 'classnames';
 import React, {useEffect, useState} from 'react';
 
 import CodeMirrorEditor from '../CodeMirrorEditor';
+import NullableCheckbox from './NullableCheckbox';
 
 function JSONInput({
 	disabled,
 	value,
 	label = Liferay.Language.get('json'),
 	name,
+	nullable,
 	setFieldValue,
 	setFieldTouched,
 }) {
@@ -32,14 +34,27 @@ function JSONInput({
 	// when called directly inside its onChange
 
 	return (
-		<div
-			className={getCN('custom-json', {disabled})}
-			onBlur={() => setFieldTouched(name)}
-		>
-			<label>{label}</label>
+		<>
+			<div
+				className={getCN('custom-json', {
+					disabled: disabled || value === null,
+				})}
+				onBlur={() => setFieldTouched(name)}
+			>
+				<label>{label}</label>
 
-			<CodeMirrorEditor onChange={setEditValue} value={editValue} />
-		</div>
+				<CodeMirrorEditor onChange={setEditValue} value={editValue} />
+			</div>
+
+			{nullable && (
+				<NullableCheckbox
+					defaultValue={editValue}
+					disabled={disabled}
+					onChange={(val) => setFieldValue(name, val)}
+					value={value}
+				/>
+			)}
+		</>
 	);
 }
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/MultiSelectInput.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/MultiSelectInput.js
@@ -12,10 +12,13 @@
 import ClayMultiSelect from '@clayui/multi-select';
 import React, {useState} from 'react';
 
+import NullableCheckbox from './NullableCheckbox';
+
 function MultiSelectInput({
 	disabled,
 	label,
 	name,
+	nullable,
 	setFieldTouched,
 	setFieldValue,
 	value,
@@ -23,26 +26,37 @@ function MultiSelectInput({
 	const [inputValue, setInputValue] = useState('');
 
 	return (
-		<ClayMultiSelect
-			aria-label={label}
-			disabled={disabled}
-			inputValue={inputValue}
-			items={value}
-			onBlur={() => {
-				if (inputValue) {
-					setFieldValue(name, [
-						...value,
-						{label: inputValue, value: inputValue},
-					]);
+		<>
+			<ClayMultiSelect
+				aria-label={label}
+				disabled={disabled || value === null}
+				inputValue={inputValue}
+				items={value || []}
+				onBlur={() => {
+					if (inputValue) {
+						setFieldValue(name, [
+							...value,
+							{label: inputValue, value: inputValue},
+						]);
 
-					setInputValue('');
-				}
+						setInputValue('');
+					}
 
-				setFieldTouched(name);
-			}}
-			onChange={setInputValue}
-			onItemsChange={(value) => setFieldValue(name, value)}
-		/>
+					setFieldTouched(name);
+				}}
+				onChange={setInputValue}
+				onItemsChange={(value) => setFieldValue(name, value)}
+			/>
+
+			{nullable && (
+				<NullableCheckbox
+					defaultValue={[]}
+					disabled={disabled}
+					onChange={(val) => setFieldValue(name, val)}
+					value={value}
+				/>
+			)}
+		</>
 	);
 }
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/NullableCheckbox.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/NullableCheckbox.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import {ClayCheckbox} from '@clayui/form';
+import React from 'react';
+
+function NullableCheckbox({defaultValue = '', disabled, onChange, value}) {
+	return (
+		<div className="form-check">
+			<ClayCheckbox
+				aria-label={Liferay.Language.get('exclude-property')}
+				checked={value === null}
+				disabled={disabled}
+				label={Liferay.Language.get('exclude-property')}
+				onChange={() => onChange(value === null ? defaultValue : null)}
+			/>
+		</div>
+	);
+}
+
+export default NullableCheckbox;

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/NumberInput.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/NumberInput.js
@@ -13,6 +13,8 @@ import {ClayInput} from '@clayui/form';
 import getCN from 'classnames';
 import React from 'react';
 
+import NullableCheckbox from './NullableCheckbox';
+
 function NumberInput({
 	configKey,
 	disabled,
@@ -20,45 +22,59 @@ function NumberInput({
 	max,
 	min,
 	name,
+	nullable,
 	onBlur,
 	onChange,
+	setFieldValue,
 	step,
 	unit,
 	value,
 }) {
 	return (
-		<ClayInput.Group small>
-			<ClayInput.GroupItem
-				className={getCN({
-					'arrowless-input':
-						unit || (configKey && configKey.includes('id')),
-				})}
-				prepend
-			>
-				<ClayInput
-					aria-label={label}
+		<>
+			<ClayInput.Group small>
+				<ClayInput.GroupItem
+					className={getCN({
+						'arrowless-input':
+							unit || (configKey && configKey.includes('id')),
+					})}
+					prepend
+				>
+					<ClayInput
+						aria-label={label}
+						disabled={disabled || value === null}
+						max={max}
+						min={min}
+						name={name}
+						onBlur={onBlur}
+						onChange={onChange}
+						step={step}
+						type="number"
+						value={value === null ? '' : value}
+					/>
+				</ClayInput.GroupItem>
+
+				{unit && (
+					<ClayInput.GroupItem append shrink>
+						<ClayInput.GroupText
+							className={getCN({
+								secondary: disabled || value === null,
+							})}
+						>
+							{unit}
+						</ClayInput.GroupText>
+					</ClayInput.GroupItem>
+				)}
+			</ClayInput.Group>
+
+			{nullable && (
+				<NullableCheckbox
 					disabled={disabled}
-					max={max}
-					min={min}
-					name={name}
-					onBlur={onBlur}
-					onChange={onChange}
-					step={step}
-					type="number"
+					onChange={(val) => setFieldValue(name, val)}
 					value={value}
 				/>
-			</ClayInput.GroupItem>
-
-			{unit && (
-				<ClayInput.GroupItem append shrink>
-					<ClayInput.GroupText
-						className={getCN({secondary: disabled})}
-					>
-						{unit}
-					</ClayInput.GroupText>
-				</ClayInput.GroupItem>
 			)}
-		</ClayInput.Group>
+		</>
 	);
 }
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/SelectInput.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/SelectInput.js
@@ -10,9 +10,7 @@
  */
 
 import {ClaySelect} from '@clayui/form';
-import React, {useRef} from 'react';
-
-import NullableCheckbox from './NullableCheckbox';
+import React from 'react';
 
 function SelectInput({
 	disabled,
@@ -22,24 +20,18 @@ function SelectInput({
 	onBlur,
 	onChange,
 	options = [],
-	setFieldValue,
 	value,
 }) {
-	const selectRef = useRef(value || options[0]?.value || '');
-
 	return (
 		<>
 			<ClaySelect
 				aria-label={label}
 				className="form-control-sm"
-				disabled={disabled || value === null}
+				disabled={disabled}
 				name={name}
 				onBlur={onBlur}
-				onChange={(event) => {
-					selectRef.current = event.target.value;
-					onChange(event);
-				}}
-				value={value || selectRef.current}
+				onChange={onChange}
+				value={value}
 			>
 				{options.map((item) => (
 					<ClaySelect.Option
@@ -48,16 +40,11 @@ function SelectInput({
 						value={item.value}
 					/>
 				))}
-			</ClaySelect>
 
-			{nullable && (
-				<NullableCheckbox
-					defaultValue={selectRef.current}
-					disabled={disabled}
-					onChange={(val) => setFieldValue(name, val)}
-					value={value}
-				/>
-			)}
+				{(nullable || value === '') && (
+					<ClaySelect.Option key="" label="" value="" />
+				)}
+			</ClaySelect>
 		</>
 	);
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/SelectInput.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/SelectInput.js
@@ -25,7 +25,7 @@ function SelectInput({
 	setFieldValue,
 	value,
 }) {
-	const selectRef = useRef(value || (options[0] && options[0].value) || '');
+	const selectRef = useRef(value || options[0]?.value || '');
 
 	return (
 		<>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/SelectInput.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/SelectInput.js
@@ -10,43 +10,55 @@
  */
 
 import {ClaySelect} from '@clayui/form';
-import React from 'react';
+import React, {useRef} from 'react';
+
+import NullableCheckbox from './NullableCheckbox';
 
 function SelectInput({
 	disabled,
 	label,
 	name,
-	options,
-	setFieldTouched,
+	nullable,
+	onBlur,
+	onChange,
+	options = [],
 	setFieldValue,
 	value,
 }) {
-	return (
-		<ClaySelect
-			aria-label={label}
-			className="form-control-sm"
-			disabled={disabled}
-			onBlur={() => setFieldTouched(name)}
-			onChange={(event) => {
-				const value =
-					typeof options[0].value == 'boolean' ||
-					typeof options[0].value == 'number'
-						? JSON.parse(event.target.value)
-						: event.target.value;
+	const selectRef = useRef(value || (options[0] && options[0].value) || '');
 
-				setFieldValue(name, value);
-			}}
-			value={value}
-		>
-			{options &&
-				options.map((item) => (
+	return (
+		<>
+			<ClaySelect
+				aria-label={label}
+				className="form-control-sm"
+				disabled={disabled || value === null}
+				name={name}
+				onBlur={onBlur}
+				onChange={(event) => {
+					selectRef.current = event.target.value;
+					onChange(event);
+				}}
+				value={value || selectRef.current}
+			>
+				{options.map((item) => (
 					<ClaySelect.Option
 						key={item.value}
 						label={item.label}
 						value={item.value}
 					/>
 				))}
-		</ClaySelect>
+			</ClaySelect>
+
+			{nullable && (
+				<NullableCheckbox
+					defaultValue={selectRef.current}
+					disabled={disabled}
+					onChange={(val) => setFieldValue(name, val)}
+					value={value}
+				/>
+			)}
+		</>
 	);
 }
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/SliderInput.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/SliderInput.js
@@ -15,6 +15,8 @@ import ClayIcon from '@clayui/icon';
 import ClaySlider from '@clayui/slider';
 import React, {useState} from 'react';
 
+import NullableCheckbox from './NullableCheckbox';
+
 function SliderInput({
 	disabled,
 	id,
@@ -22,6 +24,7 @@ function SliderInput({
 	max,
 	min,
 	name,
+	nullable,
 	onBlur,
 	onChange,
 	setFieldTouched,
@@ -41,7 +44,7 @@ function SliderInput({
 				<ClayInput.GroupItem className="arrowless-input">
 					<ClayInput
 						aria-label={label}
-						disabled={disabled}
+						disabled={disabled || value === null}
 						id={id}
 						insetAfter
 						max={max}
@@ -51,13 +54,13 @@ function SliderInput({
 						onChange={onChange}
 						step={step}
 						type="number"
-						value={value}
+						value={value === null ? '' : value}
 					/>
 
 					<ClayInput.GroupInsetItem after>
 						<ClayButton
 							aria-label={Liferay.Language.get('slider')}
-							disabled={disabled}
+							disabled={disabled || value === null}
 							displayType="unstyled"
 							onClick={() => setActive(!active)}
 						>
@@ -75,9 +78,17 @@ function SliderInput({
 						onBlur={() => setFieldTouched(name)}
 						onValueChange={_handleSliderChange}
 						step={step}
-						value={value}
+						value={value === null ? '' : value}
 					/>
 				</div>
+			)}
+
+			{nullable && (
+				<NullableCheckbox
+					disabled={disabled}
+					onChange={(val) => setFieldValue(name, val)}
+					value={value}
+				/>
 			)}
 		</>
 	);

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/TextInput.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/TextInput.js
@@ -12,20 +12,41 @@
 import {ClayInput} from '@clayui/form';
 import React from 'react';
 
-function TextInput({disabled, label, name, onBlur, onChange, value}) {
+import NullableCheckbox from './NullableCheckbox';
+
+function TextInput({
+	disabled,
+	label,
+	name,
+	nullable,
+	onBlur,
+	onChange,
+	setFieldValue,
+	value,
+}) {
 	return (
-		<ClayInput.Group small>
-			<ClayInput.GroupItem prepend>
-				<ClayInput
-					aria-label={label}
+		<>
+			<ClayInput.Group small>
+				<ClayInput.GroupItem prepend>
+					<ClayInput
+						aria-label={label}
+						disabled={disabled || value === null}
+						name={name}
+						onBlur={onBlur}
+						onChange={onChange}
+						value={value || ''}
+					/>
+				</ClayInput.GroupItem>
+			</ClayInput.Group>
+
+			{nullable && (
+				<NullableCheckbox
 					disabled={disabled}
-					name={name}
-					onBlur={onBlur}
-					onChange={onChange}
+					onChange={(val) => setFieldValue(name, val)}
 					value={value}
 				/>
-			</ClayInput.GroupItem>
-		</ClayInput.Group>
+			)}
+		</>
 	);
 }
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/index.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/index.js
@@ -105,6 +105,9 @@ function Element({
 		const inputName = _getInputName(config.name);
 		const typeOptions = config.typeOptions || {};
 
+		const nullable =
+			typeOptions.nullable || uiConfigurationValues[config.name] === null;
+
 		switch (config.type) {
 			case INPUT_TYPES.DATE:
 				return (
@@ -112,6 +115,7 @@ function Element({
 						configKey={config.name}
 						disabled={disabled}
 						name={inputName}
+						nullable={nullable}
 						setFieldTouched={setFieldTouched}
 						setFieldValue={setFieldValue}
 						value={uiConfigurationValues[config.name]}
@@ -124,6 +128,7 @@ function Element({
 						id={inputId}
 						indexFields={indexFields}
 						name={inputName}
+						nullable={nullable}
 						setFieldTouched={setFieldTouched}
 						setFieldValue={setFieldValue}
 						showBoost={typeOptions.boost}
@@ -137,6 +142,7 @@ function Element({
 						id={inputId}
 						indexFields={indexFields}
 						name={inputName}
+						nullable={nullable}
 						onBlur={onBlur}
 						setFieldTouched={setFieldTouched}
 						setFieldValue={setFieldValue}
@@ -152,6 +158,7 @@ function Element({
 						itemType={typeOptions.itemType}
 						label={config.label}
 						name={inputName}
+						nullable={nullable}
 						setFieldTouched={setFieldTouched}
 						setFieldValue={setFieldValue}
 						value={uiConfigurationValues[config.name]}
@@ -163,6 +170,7 @@ function Element({
 						disabled={disabled}
 						label={config.label}
 						name={inputName}
+						nullable={nullable}
 						setFieldTouched={setFieldTouched}
 						setFieldValue={setFieldValue}
 						value={uiConfigurationValues[config.name]}
@@ -174,6 +182,7 @@ function Element({
 						disabled={disabled}
 						label={config.label}
 						name={inputName}
+						nullable={nullable}
 						setFieldTouched={setFieldTouched}
 						setFieldValue={setFieldValue}
 						value={uiConfigurationValues[config.name]}
@@ -189,8 +198,10 @@ function Element({
 						max={typeOptions.max}
 						min={typeOptions.min}
 						name={inputName}
+						nullable={nullable}
 						onBlur={onBlur}
 						onChange={onChange}
+						setFieldValue={setFieldValue}
 						step={typeOptions.step}
 						unit={typeOptions.unit}
 						value={uiConfigurationValues[config.name]}
@@ -203,8 +214,10 @@ function Element({
 						disabled={disabled}
 						label={config.label}
 						name={inputName}
+						nullable={nullable}
+						onBlur={onBlur}
+						onChange={onChange}
 						options={typeOptions.options}
-						setFieldTouched={setFieldTouched}
 						setFieldValue={setFieldValue}
 						value={uiConfigurationValues[config.name]}
 					/>
@@ -217,6 +230,7 @@ function Element({
 						max={typeOptions.max}
 						min={typeOptions.min}
 						name={inputName}
+						nullable={nullable}
 						onBlur={onBlur}
 						onChange={onChange}
 						setFieldTouched={setFieldTouched}
@@ -231,8 +245,10 @@ function Element({
 						disabled={disabled}
 						label={config.label}
 						name={inputName}
+						nullable={nullable}
 						onBlur={onBlur}
 						onChange={onChange}
+						setFieldValue={setFieldValue}
 						value={uiConfigurationValues[config.name]}
 					/>
 				);

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/index.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/index.js
@@ -44,6 +44,7 @@ function Element({
 	id,
 	index,
 	indexFields = [],
+	isSubmitting,
 	onBlur = () => {},
 	onChange = () => {},
 	onDeleteElement,
@@ -99,7 +100,7 @@ function Element({
 		!!error.uiConfigurationValues[config.name];
 
 	const _renderInput = (config) => {
-		const disabled = !elementTemplateJSON.enabled;
+		const disabled = !elementTemplateJSON.enabled || isSubmitting;
 		const inputId = _getInputId(id, config.name);
 		const inputName = _getInputName(config.name);
 		const typeOptions = config.typeOptions || {};
@@ -458,6 +459,7 @@ Element.propTypes = {
 	id: PropTypes.number,
 	index: PropTypes.number,
 	indexFields: PropTypes.arrayOf(PropTypes.object),
+	isSubmitting: PropTypes.bool,
 	onBlur: PropTypes.func,
 	onChange: PropTypes.func,
 	onDeleteElement: PropTypes.func,

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/index.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/shared/element/index.js
@@ -87,17 +87,12 @@ function Element({
 		!isEmpty(elementTemplateJSON.description[locale]);
 
 	const _hasConfigurationValues =
-		!!uiConfigurationJSON &&
-		uiConfigurationJSON.fieldSets &&
-		uiConfigurationJSON.fieldSets.some(
-			(item) => item.fields && item.fields.length > 0
-		);
+		Array.isArray(uiConfigurationJSON?.fieldSets) &&
+		uiConfigurationJSON.fieldSets.some((item) => item.fields?.length > 0);
 
 	const _hasError = (config) =>
-		touched.uiConfigurationValues &&
-		touched.uiConfigurationValues[config.name] &&
-		error.uiConfigurationValues &&
-		!!error.uiConfigurationValues[config.name];
+		touched.uiConfigurationValues?.[config.name] &&
+		!!error.uiConfigurationValues?.[config.name];
 
 	const _renderInput = (config) => {
 		const disabled = !elementTemplateJSON.enabled || isSubmitting;
@@ -384,7 +379,7 @@ function Element({
 			{!collapse && _hasConfigurationValues && (
 				<ClayList className="configuration-form-list">
 					{uiConfigurationJSON.fieldSets.map((fieldSet) => {
-						if (fieldSet.fields) {
+						if (Array.isArray(fieldSet.fields)) {
 							return fieldSet.fields.map((config) => (
 								<ClayList.Item
 									className={config.type}
@@ -401,11 +396,9 @@ function Element({
 											>
 												{config.label}
 
-												{config.typeOptions &&
-													isDefined(
-														config.typeOptions
-															.required
-													) &&
+												{isDefined(
+													config.typeOptions?.required
+												) &&
 													!config.typeOptions
 														.required && (
 														<span className="optional-text">

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/utils/utils.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/utils/utils.js
@@ -339,10 +339,14 @@ export const getElementOutput = ({
 					const initialConfigValue =
 						uiConfigurationValues[config.name];
 
-					if (initialConfigValue === null) {
+					if (
+						initialConfigValue === null ||
+						(config.type === INPUT_TYPES.SELECT &&
+							initialConfigValue === '')
+					) {
 
-						// Remove property entirely if null. Check for regex with leading and trailing
-						// commas first.
+						// Remove property entirely if null (or blank for a select inputs).
+						// Check for regex with leading and trailing commas first.
 
 						const nullRegex = `\\"[\\w\\._]+\\"\\:\\"\\$\\{${CONFIG_PREFIX}\\.${config.name}}\\"`;
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/utils/utils.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/utils/utils.js
@@ -34,7 +34,7 @@ export const openSuccessToast = (config) => {
 };
 
 /**
- * Function used to identify whether a required value is not null or undefined
+ * Function used to identify whether a required value is not undefined
  *
  * Examples:
  * isDefined(false)
@@ -44,12 +44,12 @@ export const openSuccessToast = (config) => {
  * isDefined('')
  * => true
  * isDefined(null)
- * => false
+ * => true
  *
  * @param {String|object} item Item to check
  * @return {boolean}
  */
-export const isDefined = (item) => item !== null && typeof item !== 'undefined';
+export const isDefined = (item) => typeof item !== 'undefined';
 
 /**
  * Checks if a value is blank. For example: `''` or `{}`.
@@ -205,6 +205,12 @@ export const getDefaultValue = (item) => {
 	const itemValue = item.defaultValue;
 	const itemTypeOptions = item.typeOptions || {};
 
+	const itemOptions = itemTypeOptions.options || [];
+
+	if (itemValue === null) {
+		return itemValue;
+	}
+
 	switch (item.type) {
 		case INPUT_TYPES.DATE:
 			return typeof itemValue == 'number'
@@ -242,14 +248,10 @@ export const getDefaultValue = (item) => {
 				? toNumber(itemValue)
 				: '';
 		case INPUT_TYPES.SELECT:
-
-			// use isDefined in case of false or 0
-
-			return isDefined(itemValue)
+			return typeof itemValue === 'string'
 				? itemValue
-				: itemTypeOptions.options &&
-				  isDefined(itemTypeOptions.options[0].value)
-				? itemTypeOptions.options[0].value
+				: itemOptions[0] && itemOptions[0].value
+				? itemOptions[0].value
 				: '';
 		case INPUT_TYPES.SLIDER:
 			return typeof itemValue == 'number'
@@ -340,7 +342,32 @@ export const getElementOutput = ({
 						uiConfigurationValues[config.name];
 					const configTypeOptions = config.typeOptions || {};
 
-					if (config.type === INPUT_TYPES.DATE) {
+					if (initialConfigValue === null) {
+
+						// Remove property entirely if null. Check for regex with leading and trailing
+						// commas first.
+
+						const nullRegex = `\\"[\\w\\._]+\\"\\:\\"\\$\\{${CONFIG_PREFIX}\\.${config.name}}\\"`;
+
+						flattenJSON = replaceStr(
+							flattenJSON,
+							new RegExp(nullRegex + `,`),
+							''
+						);
+
+						flattenJSON = replaceStr(
+							flattenJSON,
+							new RegExp(`,` + nullRegex),
+							''
+						);
+
+						flattenJSON = replaceStr(
+							flattenJSON,
+							new RegExp(nullRegex),
+							''
+						);
+					}
+					else if (config.type === INPUT_TYPES.DATE) {
 						configValue = initialConfigValue
 							? JSON.parse(
 									moment
@@ -382,6 +409,12 @@ export const getElementOutput = ({
 							localizedField = field + transformedLocale;
 						}
 
+						localizedField = replaceStr(
+							localizedField,
+							/[\\"]+/,
+							''
+						);
+
 						configValue =
 							boost && boost > 0
 								? `${localizedField}^${boost}`
@@ -418,6 +451,12 @@ export const getElementOutput = ({
 											field + transformedLocale;
 									}
 
+									localizedField = replaceStr(
+										localizedField,
+										/[\\"]+/,
+										''
+									);
+
 									return boost && boost > 0
 										? `${localizedField}^${boost}`
 										: localizedField;
@@ -452,15 +491,21 @@ export const getElementOutput = ({
 									  )
 								: initialConfigValue;
 					}
-					else {
+					else if (config.type === INPUT_TYPES.SLIDER) {
 						configValue = initialConfigValue;
+					}
+					else {
+						configValue = replaceStr(
+							initialConfigValue,
+							/[\\"]+/,
+							''
+						);
 					}
 
 					// Check whether to add quotes around output
 
 					const key =
 						typeof configValue === 'number' ||
-						typeof configValue === 'boolean' ||
 						config.type === INPUT_TYPES.ITEM_SELECTOR ||
 						config.type === INPUT_TYPES.FIELD_MAPPING_LIST ||
 						config.type === INPUT_TYPES.JSON ||

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/utils/utils.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/utils/utils.js
@@ -203,9 +203,6 @@ export const toNumber = (str) => {
  */
 export const getDefaultValue = (item) => {
 	const itemValue = item.defaultValue;
-	const itemTypeOptions = item.typeOptions || {};
-
-	const itemOptions = itemTypeOptions.options || [];
 
 	if (itemValue === null) {
 		return itemValue;
@@ -250,8 +247,8 @@ export const getDefaultValue = (item) => {
 		case INPUT_TYPES.SELECT:
 			return typeof itemValue === 'string'
 				? itemValue
-				: itemOptions[0] && itemOptions[0].value
-				? itemOptions[0].value
+				: item.typeOptions?.options?.[0]?.value
+				? item.typeOptions.options[0].value
 				: '';
 		case INPUT_TYPES.SLIDER:
 			return typeof itemValue == 'number'
@@ -298,15 +295,16 @@ export const getDefaultValue = (item) => {
  * @return {object}
  */
 export const getUIConfigurationValues = (uiConfigurationJSON) => {
-	if (uiConfigurationJSON && uiConfigurationJSON.fieldSets) {
+	if (Array.isArray(uiConfigurationJSON?.fieldSets)) {
 		return uiConfigurationJSON.fieldSets.reduce((allValues, fieldSet) => {
-			const uiConfigurationValues = fieldSet.fields
-				? fieldSet.fields.reduce((acc, curr) => {
-						return {
+			const uiConfigurationValues = Array.isArray(fieldSet.fields)
+				? fieldSet.fields.reduce(
+						(acc, curr) => ({
 							...acc,
 							[`${curr.name}`]: getDefaultValue(curr),
-						};
-				  }, {})
+						}),
+						{}
+				  )
 				: {};
 
 			// gets uiConfigurationValues within each fields array
@@ -331,16 +329,15 @@ export const getElementOutput = ({
 	uiConfigurationJSON,
 	uiConfigurationValues,
 }) => {
-	if (uiConfigurationJSON && uiConfigurationJSON.fieldSets) {
+	if (Array.isArray(uiConfigurationJSON?.fieldSets)) {
 		let flattenJSON = JSON.stringify(elementTemplateJSON);
 
 		uiConfigurationJSON.fieldSets.map((fieldSet) => {
-			if (fieldSet.fields) {
+			if (Array.isArray(fieldSet.fields)) {
 				fieldSet.fields.map((config) => {
 					let configValue = '';
 					const initialConfigValue =
 						uiConfigurationValues[config.name];
-					const configTypeOptions = config.typeOptions || {};
 
 					if (initialConfigValue === null) {
 
@@ -373,7 +370,7 @@ export const getElementOutput = ({
 									moment
 										.unix(initialConfigValue)
 										.format(
-											configTypeOptions.format ||
+											config.typeOptions?.format ||
 												'YYYYMMDDHHMMSS'
 										)
 							  )
@@ -481,13 +478,13 @@ export const getElementOutput = ({
 					}
 					else if (config.type === INPUT_TYPES.NUMBER) {
 						configValue =
-							typeof configTypeOptions.unitSuffix == 'string'
+							typeof config.typeOptions?.unitSuffix == 'string'
 								? typeof initialConfigValue == 'string'
 									? initialConfigValue.concat(
-											configTypeOptions.unitSuffix
+											config.typeOptions?.unitSuffix
 									  )
 									: JSON.stringify(initialConfigValue).concat(
-											configTypeOptions.unitSuffix
+											config.typeOptions?.unitSuffix
 									  )
 								: initialConfigValue;
 					}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/utils/validation.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/utils/validation.js
@@ -14,6 +14,10 @@ import {INPUT_TYPES} from './inputTypes';
 import {isDefined, sub} from './utils';
 
 export const validateBoost = (configValue, type) => {
+	if (configValue === null) {
+		return;
+	}
+
 	if (type === INPUT_TYPES.FIELD_MAPPING && configValue.boost < 0) {
 		return ERROR_MESSAGES.NEGATIVE_BOOST;
 	}
@@ -27,11 +31,11 @@ export const validateBoost = (configValue, type) => {
 };
 
 export const validateJSON = (configValue, type) => {
-	if (
-		!isDefined(configValue) ||
-		configValue == '' ||
-		type !== INPUT_TYPES.JSON
-	) {
+	if (configValue === null || !isDefined(configValue) || configValue == '') {
+		return;
+	}
+
+	if (type !== INPUT_TYPES.JSON) {
 		return;
 	}
 
@@ -44,6 +48,9 @@ export const validateJSON = (configValue, type) => {
 };
 
 export const validateNumberRange = (configValue, type, typeOptions) => {
+	if (configValue === null) {
+		return;
+	}
 	if (![INPUT_TYPES.NUMBER, INPUT_TYPES.SLIDER].includes(type)) {
 		return;
 	}
@@ -58,7 +65,7 @@ export const validateNumberRange = (configValue, type, typeOptions) => {
 };
 
 export const validateRequired = (configValue, type, required = true) => {
-	if (!required) {
+	if (!required || configValue === null) {
 		return;
 	}
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/utils/validation.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/META-INF/resources/js/utils/validation.js
@@ -69,7 +69,7 @@ export const validateRequired = (configValue, type, required = true) => {
 		return;
 	}
 
-	if (configValue === '') {
+	if (configValue === '' && type !== INPUT_TYPES.SELECT) {
 		return ERROR_MESSAGES.REQUIRED;
 	}
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/content/Language.properties
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/content/Language.properties
@@ -51,6 +51,7 @@ error.default-locale-description-empty=Description for the default locale was em
 error.default-locale-title-empty=The title for the default locale cannot be blank.
 error.description-empty=Description was empty.
 error.title-empty=The title cannot be blank.
+exclude-property=Exclude property
 facets=Facets
 facets-configuration=Facet Configuration
 framework=Framework

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/content/Language.properties
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/resources/content/Language.properties
@@ -36,6 +36,7 @@ compose-elements-on-top-of-liferay-default-search-clauses=Compose Elements on to
 created-by-x-x-ago=Created by {0} {1} ago
 custom-clauses=Custom Clauses
 custom-json-element=Custom JSON Element
+document-fields=Document Fields
 edit-blueprint=Edit Blueprint
 edit-description=Edit Description
 edit-element=Edit Element

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/test/js/mocks/data.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/test/js/mocks/data.js
@@ -135,13 +135,13 @@ export const ELEMENT_OUTPUTS = SELECTED_ELEMENTS.map(getElementOutput);
 export const INITIAL_CONFIGURATION = {
 	advanced_configuration: {
 		query_processing: {
-			exclude_query_contributors: '',
-			exclude_query_post_processors: '',
+			exclude_query_contributors: [],
+			exclude_query_post_processors: [],
 		},
 		source: {
 			fetch_source: true,
-			source_excludes: '',
-			source_includes: '',
+			source_excludes: [],
+			source_includes: [],
 		},
 	},
 	aggregation_configuration: [],

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/test/js/utils/utils.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/test/js/utils/utils.js
@@ -25,8 +25,8 @@ describe('utils', () => {
 			expect(isDefined(undefined)).toEqual(false);
 		});
 
-		it('returns false for null', () => {
-			expect(isDefined(null)).toEqual(false);
+		it('returns true for null', () => {
+			expect(isDefined(null)).toEqual(true);
 		});
 
 		it('returns true for empty string', () => {
@@ -130,49 +130,27 @@ describe('utils', () => {
 		it('gets default value for select', () => {
 			expect(
 				getDefaultValue({
-					defaultValue: false,
+					defaultValue: 'fuzzy_value',
 					label: 'Enabled',
 					name: 'enabled',
 					type: 'select',
 					typeOptions: {
 						options: [
 							{
-								label: 'True',
-								value: true,
+								label: 'Best Value',
+								value: 'best_value',
 							},
 							{
-								label: 'False',
-								value: false,
+								label: 'Fuzzy Value',
+								value: 'fuzzy_value',
 							},
 						],
 					},
 				})
-			).toEqual(false);
+			).toEqual('fuzzy_value');
 		});
 
-		it('gets default value for empty select with boolean', () => {
-			expect(
-				getDefaultValue({
-					label: 'Enabled',
-					name: 'enabled',
-					type: 'select',
-					typeOptions: {
-						options: [
-							{
-								label: 'True',
-								value: true,
-							},
-							{
-								label: 'False',
-								value: false,
-							},
-						],
-					},
-				})
-			).toEqual(true); // Gets first value in options
-		});
-
-		it('gets default value for empty select with string', () => {
+		it('gets default value for empty select', () => {
 			expect(
 				getDefaultValue({
 					label: 'Value',

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/blueprints/blade_sample.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/blueprints/blade_sample.json
@@ -3,8 +3,10 @@
 		"configuration": {
 			"advanced_configuration": {
 				"query_processing": {
-					"exclude_query_contributors": "",
-					"exclude_query_post_processors": ""
+					"exclude_query_contributors": [
+					],
+					"exclude_query_post_processors": [
+					]
 				},
 				"source": {
 					"fetch_source": true,

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/blueprints/content_driven.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/blueprints/content_driven.json
@@ -3,13 +3,17 @@
 		"configuration": {
 			"advanced_configuration": {
 				"query_processing": {
-					"exclude_query_contributors": "",
-					"exclude_query_post_processors": ""
+					"exclude_query_contributors": [
+					],
+					"exclude_query_post_processors": [
+					]
 				},
 				"source": {
 					"fetch_source": true,
-					"source_excludes": "",
-					"source_includes": ""
+					"source_excludes": [
+					],
+					"source_includes": [
+					]
 				}
 			},
 			"aggregation_configuration": [

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/blueprints/personalization.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/blueprints/personalization.json
@@ -3,13 +3,17 @@
 		"configuration": {
 			"advanced_configuration": {
 				"query_processing": {
-					"exclude_query_contributors": "",
-					"exclude_query_post_processors": ""
+					"exclude_query_contributors": [
+					],
+					"exclude_query_post_processors": [
+					]
 				},
 				"source": {
 					"fetch_source": true,
-					"source_excludes": "",
-					"source_includes": ""
+					"source_excludes": [
+					],
+					"source_includes": [
+					]
 				}
 			},
 			"aggregation_configuration": [

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category_for_a_period_of_time.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/boost_contents_in_a_category_for_a_period_of_time.json
@@ -54,16 +54,20 @@
 								"type": "number"
 							},
 							{
-								"format": "YYYYMMDD",
 								"label": "Create Date: From",
 								"name": "start_date",
-								"type": "date"
+								"type": "date",
+								"typeOptions": {
+									"format": "YYYYMMDD"
+								}
 							},
 							{
-								"format": "YYYYMMDD",
 								"label": "Create Date: To",
 								"name": "end_date",
-								"type": "date"
+								"type": "date",
+								"typeOptions": {
+									"format": "YYYYMMDD"
+								}
 							},
 							{
 								"defaultValue": 10,

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/text_match_over_multiple_fields.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-resources/src/main/resources/META-INF/search/elements/text_match_over_multiple_fields.json
@@ -14,8 +14,10 @@
 										"boost": "${configuration.boost}",
 										"fields": "${configuration.fields}",
 										"fuzziness": "${configuration.fuzziness}",
+										"minimum_should_match": "${configuration.minimum_should_match}",
 										"operator": "${configuration.operator}",
 										"query": "${keywords}",
+										"slop": "${configuration.slop}",
 										"type": "${configuration.type}"
 									}
 								}
@@ -111,10 +113,13 @@
 								}
 							},
 							{
+								"defaultValue": "AUTO",
+								"helpText": "Only use fuzziness with the following match types: most fields, best fields, bool prefix.",
 								"label": "Fuzziness",
 								"name": "fuzziness",
 								"type": "select",
 								"typeOptions": {
+									"nullable": true,
 									"options": [
 										{
 											"label": "Auto",
@@ -142,6 +147,27 @@
 								"type": "number",
 								"typeOptions": {
 									"min": 0
+								}
+							},
+							{
+								"defaultValue": "1",
+								"label": "Minimum Should Match",
+								"name": "minimum_should_match",
+								"type": "text",
+								"typeOptions": {
+									"nullable": true
+								}
+							},
+							{
+								"defaultValue": null,
+								"helpText": "Only use slop with the following match types: phrase, phrase prefix.",
+								"label": "Slop",
+								"name": "slop",
+								"type": "number",
+								"typeOptions": {
+									"min": 0,
+									"nullable": true,
+									"step": 1
 								}
 							}
 						]


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-130992 - Prevent invalid value combinations in "Text Match Over Multiple Fields" (updated description to include a testable element)
https://issues.liferay.com/browse/LPS-130993 - Add new properties to "Text Match Over Multiple Fields" (might need to update this once Petteri gets back to us!)

Here's some notes about this PR:
- `null` is now a valid option as a defaultValue, so validation was changed to accept `null` values
- util.js's `isDefined` was updated to pass for only undefined values, since we have separate checking for null values now
- From testing, it looked like ClaySelect never really accepted anything other that String values, so updated the parts of code that would have accepted boolean/numbers on SelectInput
- Using moment sometimes had a `Moment construction falls back to js Date` warning in console, so small fix for that
- Typing in `\` or `"` would make text fields error out when it came time to parse JSON, so added a step to replace those 

Let me know what you think, thanks!