### PR TITLE
Lps 141045 edit sxp blueprint recode 11 18 21

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/AddSXPElementSidebar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/AddSXPElementSidebar.js
@@ -81,18 +81,14 @@ const SXPElementList = ({category, expand, onAddSXPElement, sxpElements}) => {
 							{sxpElementTemplateJSON, uiConfigurationJSON},
 							index
 						) => {
-							const description =
-								sxpElementTemplateJSON.description ||
-								getLocalizedText(
-									sxpElementTemplateJSON.description_i18n,
-									locale
-								);
-							const title =
-								sxpElementTemplateJSON.title ||
-								getLocalizedText(
-									sxpElementTemplateJSON.title_i18n,
-									locale
-								);
+							const description = getLocalizedText(
+								sxpElementTemplateJSON.description_i18n,
+								locale
+							);
+							const title = getLocalizedText(
+								sxpElementTemplateJSON.title_i18n,
+								locale
+							);
 
 							return (
 								<ClayList.Item

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -121,22 +121,22 @@ function EditSXPBlueprintForm({
 			({
 				id, // eslint-disable-line
 				sxpElement,
+				sxpElementId,
+				type,
 				uiConfigurationValues,
-				...props
-			}) => {
-				return {
-					...props,
-					configurationEntry: getConfigurationEntry({
-						sxpElement,
-						uiConfigurationValues,
-					}),
-					sxpElement: parseCustomSXPElement(
-						sxpElement,
-						uiConfigurationValues
-					),
+			}) => ({
+				configurationEntry: getConfigurationEntry({
+					sxpElement,
 					uiConfigurationValues,
-				};
-			}
+				}),
+				sxpElement: parseCustomSXPElement(
+					sxpElement,
+					uiConfigurationValues
+				),
+				sxpElementId,
+				type,
+				uiConfigurationValues,
+			})
 		);
 
 	const _handleFormikSubmit = async (values) => {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -26,7 +26,7 @@ import {INPUT_TYPES} from '../utils/inputTypes';
 import {openErrorToast, openSuccessToast} from '../utils/toasts';
 import {
 	cleanUIConfiguration,
-	getSXPElementOutput,
+	getConfigurationEntry,
 	getUIConfigurationValues,
 	isDefined,
 	parseCustomSXPElement,
@@ -126,7 +126,7 @@ function EditSXPBlueprintForm({
 			}) => {
 				return {
 					...props,
-					configurationEntry: getSXPElementOutput({
+					configurationEntry: getConfigurationEntry({
 						sxpElement,
 						uiConfigurationValues,
 					}),

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -48,7 +48,7 @@ import SettingsTab from './settings_tab/index';
 const TABS = {
 	'query-builder': Liferay.Language.get('query-builder'),
 	'clause-contributors': Liferay.Language.get('clause-contributors'),
-	settings: Liferay.Language.get('settings'),
+	'settings': Liferay.Language.get('settings'),
 };
 /* eslint-enable sort-keys */
 
@@ -74,7 +74,9 @@ function EditSXPBlueprintForm({
 
 	const formRef = useRef();
 
-	const sxpElementIdCounterRef = useRef(initialSXPElementInstances.length || 0);
+	const sxpElementIdCounterRef = useRef(
+		initialSXPElementInstances.length || 0
+	);
 
 	const _getFormInput = (key) => {
 		for (const pair of new FormData(formRef.current).entries()) {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/index.js
@@ -25,6 +25,7 @@ import {fetchData} from '../../utils/fetch';
 import SelectTypes from './SelectTypes';
 
 function QueryBuilderTab({
+	elementInstances,
 	entityJSON,
 	errors = [],
 	frameworkConfig = {},
@@ -34,7 +35,6 @@ function QueryBuilderTab({
 	onDeleteSXPElement,
 	onFrameworkConfigChange,
 	onToggleSidebar,
-	selectedSXPElements,
 	setFieldTouched,
 	setFieldValue,
 	touched = [],
@@ -67,51 +67,48 @@ function QueryBuilderTab({
 
 	const _renderSelectedElements = () => (
 		<>
-			{selectedSXPElements.map((sxpElement, index) => {
-				return sxpElement.uiConfigurationJSON ? (
-					<SXPElement
-						collapseAll={collapseAll}
-						entityJSON={entityJSON}
-						error={errors[index]}
-						id={sxpElement.id}
-						index={index}
-						indexFields={indexFields}
-						isSubmitting={isSubmitting}
-						key={sxpElement.id}
-						onBlur={onBlur}
-						onChange={onChange}
-						onDeleteSXPElement={onDeleteSXPElement}
-						prefixedId={`${SXP_ELEMENT_PREFIX.QUERY}-${index}`}
-						searchableTypes={searchableTypes}
-						setFieldTouched={setFieldTouched}
-						setFieldValue={setFieldValue}
-						sxpElementTemplateJSON={
-							sxpElement.sxpElementTemplateJSON
-						}
-						touched={touched[index]}
-						uiConfigurationJSON={sxpElement.uiConfigurationJSON}
-						uiConfigurationValues={sxpElement.uiConfigurationValues}
-					/>
-				) : (
-					<JSONSXPElement
-						collapseAll={collapseAll}
-						error={errors[index]}
-						id={sxpElement.id}
-						index={index}
-						isSubmitting={isSubmitting}
-						key={sxpElement.id}
-						onDeleteSXPElement={onDeleteSXPElement}
-						prefixedId={`${SXP_ELEMENT_PREFIX.QUERY}-${index}`}
-						setFieldTouched={setFieldTouched}
-						setFieldValue={setFieldValue}
-						sxpElementTemplateJSON={
-							sxpElement.sxpElementTemplateJSON
-						}
-						touched={touched[index]}
-						uiConfigurationValues={sxpElement.uiConfigurationValues}
-					/>
-				);
-			})}
+			{elementInstances.map(
+				({id, sxpElement, uiConfigurationValues}, index) => {
+					return sxpElement.elementDefinition?.uiConfiguration ? (
+						<SXPElement
+							collapseAll={collapseAll}
+							entityJSON={entityJSON}
+							error={errors[index]}
+							id={id}
+							index={index}
+							indexFields={indexFields}
+							isSubmitting={isSubmitting}
+							key={id}
+							onBlur={onBlur}
+							onChange={onChange}
+							onDeleteSXPElement={onDeleteSXPElement}
+							prefixedId={`${SXP_ELEMENT_PREFIX.QUERY}-${index}`}
+							searchableTypes={searchableTypes}
+							setFieldTouched={setFieldTouched}
+							setFieldValue={setFieldValue}
+							sxpElement={sxpElement}
+							touched={touched[index]}
+							uiConfigurationValues={uiConfigurationValues}
+						/>
+					) : (
+						<JSONSXPElement
+							collapseAll={collapseAll}
+							error={errors[index]}
+							id={id}
+							index={index}
+							isSubmitting={isSubmitting}
+							key={id}
+							onDeleteSXPElement={onDeleteSXPElement}
+							prefixedId={`${SXP_ELEMENT_PREFIX.QUERY}-${index}`}
+							setFieldTouched={setFieldTouched}
+							setFieldValue={setFieldValue}
+							sxpElement={sxpElement}
+							touched={touched[index]}
+							uiConfigurationValues={uiConfigurationValues}
+						/>
+					);
+				}
+			)}
 		</>
 	);
 
@@ -164,7 +161,7 @@ function QueryBuilderTab({
 					</ClayLayout.Col>
 				</ClayLayout.Row>
 
-				{selectedSXPElements.length === 0 ? (
+				{elementInstances.length === 0 ? (
 					<div className="sheet">
 						<div className="selected-sxp-elements-empty-text">
 							{Liferay.Language.get(
@@ -222,6 +219,7 @@ function QueryBuilderTab({
 }
 
 QueryBuilderTab.propTypes = {
+	elementInstances: PropTypes.arrayOf(PropTypes.object),
 	entityJSON: PropTypes.object,
 	errors: PropTypes.arrayOf(PropTypes.object),
 	frameworkConfig: PropTypes.object,
@@ -231,7 +229,6 @@ QueryBuilderTab.propTypes = {
 	onDeleteSXPElement: PropTypes.func,
 	onFrameworkConfigChange: PropTypes.func,
 	onToggleSidebar: PropTypes.func,
-	selectedSXPElements: PropTypes.arrayOf(PropTypes.object),
 	setFieldTouched: PropTypes.func,
 	setFieldValue: PropTypes.func,
 	touched: PropTypes.arrayOf(PropTypes.object),

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
@@ -79,11 +79,11 @@ function EditSXPElementForm({
 		initialConfiguration.sxpElementTemplateJSON = {};
 	}
 
-	initialConfiguration.sxpElementTemplateJSON.title = renameKeys(
+	initialConfiguration.sxpElementTemplateJSON.title_i18n = renameKeys(
 		initialTitle,
 		(str) => str.replace('-', '_')
 	);
-	initialConfiguration.sxpElementTemplateJSON.description = renameKeys(
+	initialConfiguration.sxpElementTemplateJSON.description_i18n = renameKeys(
 		initialDescription,
 		(str) => str.replace('-', '_')
 	);

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
@@ -92,7 +92,7 @@ function EditSXPElementForm({
 		)
 	);
 	const [uiConfigurationJSON, setUIConfigurationJSON] = useState(
-		JSON.stringify(uiConfiguration, null, '\t')
+		JSON.stringify(uiConfiguration || {}, null, '\t')
 	);
 
 	useEffect(() => {
@@ -334,13 +334,28 @@ function EditSXPElementForm({
 			);
 		}
 
+		const {
+			description_i18n,
+			title_i18n,
+			...restOfSXPElementTemplateJSON
+		} = previewSXPElementTemplateJSON;
+
+		const sxpElement = {
+			description_i18n,
+			elementDefinition: {
+				uiConfiguration: previewUIConfigurationJSON,
+				...restOfSXPElementTemplateJSON,
+			},
+			title_i18n,
+			type,
+		};
+
 		return (
 			<div className="portlet-sxp-blueprint-admin">
 				<ErrorBoundary>
 					<SXPElement
 						collapseAll={false}
-						sxpElementTemplateJSON={previewSXPElementTemplateJSON}
-						uiConfigurationJSON={previewUIConfigurationJSON}
+						sxpElement={sxpElement}
 						uiConfigurationValues={getUIConfigurationValues(
 							previewUIConfigurationJSON
 						)}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
@@ -37,14 +37,14 @@ import SubmitWarningModal from '../shared/SubmitWarningModal';
 import ThemeContext from '../shared/ThemeContext';
 import SXPElement from '../shared/sxp_element/index';
 import {CONFIG_PREFIX, DEFAULT_ERROR} from '../utils/constants';
-import {renameKeys, sub} from '../utils/language';
+import {sub} from '../utils/language';
 import {openErrorToast} from '../utils/toasts';
 import {getUIConfigurationValues} from '../utils/utils';
 import SidebarPanel from './SidebarPanel';
 
 function EditSXPElementForm({
-	initialConfiguration = {},
 	initialDescription = {},
+	initialElementDefinition = {},
 	initialTitle = {},
 	predefinedVariables = [],
 	readOnly,
@@ -75,24 +75,24 @@ function EditSXPElementForm({
 
 	const [variables, setVariables] = useState(filteredCategories);
 
-	if (!initialConfiguration.sxpElementTemplateJSON) {
-		initialConfiguration.sxpElementTemplateJSON = {};
-	}
-
-	initialConfiguration.sxpElementTemplateJSON.title_i18n = renameKeys(
-		initialTitle,
-		(str) => str.replace('-', '_')
-	);
-	initialConfiguration.sxpElementTemplateJSON.description_i18n = renameKeys(
-		initialDescription,
-		(str) => str.replace('-', '_')
-	);
+	const {
+		uiConfiguration,
+		...restOfElementDefinition
+	} = initialElementDefinition;
 
 	const [sxpElementTemplateJSON, setSXPElementTemplateJSON] = useState(
-		JSON.stringify(initialConfiguration.sxpElementTemplateJSON, null, '\t')
+		JSON.stringify(
+			{
+				...restOfElementDefinition,
+				description_i18n: initialDescription,
+				title_i18n: initialTitle,
+			},
+			null,
+			'\t'
+		)
 	);
 	const [uiConfigurationJSON, setUIConfigurationJSON] = useState(
-		JSON.stringify(initialConfiguration.uiConfigurationJSON, null, '\t')
+		JSON.stringify(uiConfiguration, null, '\t')
 	);
 
 	useEffect(() => {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
@@ -171,13 +171,9 @@ function EditSXPElementForm({
 		}
 
 		const {
-			category,
-			description, //eslint-disable-line
 			description_i18n,
-			icon,
-			title, //eslint-disable-line
 			title_i18n,
-			...partialSXPBlueprint
+			...restOfSXPElementTemplateJSON
 		} = parseSXPElementTemplateJSON;
 
 		try {
@@ -198,14 +194,8 @@ function EditSXPElementForm({
 						body: JSON.stringify({
 							description_i18n,
 							elementDefinition: {
-								category,
-								icon,
-								sxpBlueprint: {
-									queryConfiguration: {
-										queryEntries: [partialSXPBlueprint],
-									},
-								},
 								uiConfiguration: parseUIConfigurationJSON,
+								...restOfSXPElementTemplateJSON,
 							},
 							title_i18n,
 							type,
@@ -230,14 +220,8 @@ function EditSXPElementForm({
 					body: JSON.stringify({
 						description_i18n,
 						elementDefinition: {
-							category,
-							icon,
-							sxpBlueprint: {
-								queryConfiguration: {
-									queryEntries: [partialSXPBlueprint],
-								},
-							},
 							uiConfiguration: parseUIConfigurationJSON,
+							...restOfSXPElementTemplateJSON,
 						},
 						title_i18n,
 						type,
@@ -286,14 +270,8 @@ function EditSXPElementForm({
 				body: JSON.stringify({
 					description_i18n,
 					elementDefinition: {
-						category,
-						icon,
-						sxpBlueprint: {
-							queryConfiguration: {
-								queryEntries: [partialSXPBlueprint],
-							},
-						},
 						uiConfiguration: parseUIConfigurationJSON,
+						...restOfSXPElementTemplateJSON,
 					},
 					title_i18n,
 					type,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/index.js
@@ -14,7 +14,6 @@ import React, {useEffect, useState} from 'react';
 import ErrorBoundary from '../shared/ErrorBoundary';
 import ThemeContext from '../shared/ThemeContext';
 import {fetchData} from '../utils/fetch';
-import {getSXPBlueprintForm} from '../utils/utils';
 import EditSXPElementForm from './EditSXPElementForm';
 
 export default function ({
@@ -61,12 +60,12 @@ export default function ({
 			<div className="edit-sxp-element-root">
 				<ErrorBoundary>
 					<EditSXPElementForm
-						initialConfiguration={getSXPBlueprintForm(sxpElement)}
 						initialDescription={
 							sxpElement.description_i18n || {
 								[defaultLocale]: sxpElement.description,
 							}
 						}
+						initialElementDefinition={sxpElement.elementDefinition}
 						initialTitle={
 							sxpElement.title_i18n || {
 								[defaultLocale]: sxpElement.title,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -82,7 +82,7 @@ const CodeMirrorEditor = React.forwardRef(
 	) => {
 		const innerRef = useRef(ref);
 		const editorWrapperRef = useRef();
-		const editor = useCombinedRefs(ref, innerRef);
+		const editorRef = useCombinedRefs(ref, innerRef);
 
 		useEffect(() => {
 			if (editorWrapperRef.current) {
@@ -124,9 +124,9 @@ const CodeMirrorEditor = React.forwardRef(
 					});
 				}
 
-				editor.current = codeMirror;
+				editorRef.current = codeMirror;
 			}
-		}, [editorWrapper]); // eslint-disable-line
+		}, [editorWrapperRef]); // eslint-disable-line
 
 		return (
 			<div

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/JSONSXPElement.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/JSONSXPElement.js
@@ -19,13 +19,14 @@ import getCN from 'classnames';
 import {PropTypes} from 'prop-types';
 import React, {useContext, useEffect, useState} from 'react';
 
+import {DEFAULT_SXP_ELEMENT_ICON} from '../utils/data';
 import {getLocalizedText} from '../utils/language';
 import ThemeContext from './ThemeContext';
 import JSONInput from './sxp_element/JSONInput';
 
 function JSONSXPElement({
 	collapseAll,
-	sxpElementTemplateJSON,
+	sxpElement,
 	error = {},
 	id,
 	index,
@@ -42,24 +43,21 @@ function JSONSXPElement({
 	const [active, setActive] = useState(false);
 	const [collapse, setCollapse] = useState(collapseAll);
 
-	const description = getLocalizedText(
-		sxpElementTemplateJSON.description_i18n,
-		locale
-	);
-	const title = getLocalizedText(sxpElementTemplateJSON.title_i18n, locale);
+	const description = getLocalizedText(sxpElement.description_i18n, locale);
+	const title = getLocalizedText(sxpElement.title_i18n, locale);
 
 	useEffect(() => {
 		setCollapse(collapseAll);
 	}, [collapseAll]);
 
 	const _inputName = () =>
-		`selectedQuerySXPElements[${index}].uiConfigurationValues.sxpElementTemplateJSON`;
+		`elementInstances[${index}].uiConfigurationValues.sxpElement`;
 
 	const _hasError = () =>
 		touched.uiConfigurationValues &&
-		touched.uiConfigurationValues.sxpElementTemplateJSON &&
+		touched.uiConfigurationValues.sxpElement &&
 		error.uiConfigurationValues &&
-		!!error.uiConfigurationValues.sxpElementTemplateJSON;
+		!!error.uiConfigurationValues.sxpElement;
 
 	return (
 		<div className="sheet sxp-element" id={prefixedId}>
@@ -67,7 +65,12 @@ function JSONSXPElement({
 				<ClayList.Item flex>
 					<ClayList.ItemField>
 						<ClaySticker size="md">
-							<ClayIcon symbol={sxpElementTemplateJSON.icon} />
+							<ClayIcon
+								symbol={
+									sxpElement.elementDefinition?.icon ||
+									DEFAULT_SXP_ELEMENT_ICON
+								}
+							/>
 						</ClaySticker>
 					</ClayList.ItemField>
 
@@ -145,8 +148,8 @@ function JSONSXPElement({
 						setFieldTouched={setFieldTouched}
 						setFieldValue={setFieldValue}
 						value={
-							uiConfigurationValues.sxpElementTemplateJSON ||
-							JSON.stringify(sxpElementTemplateJSON, null, '\t')
+							uiConfigurationValues.sxpElement ||
+							JSON.stringify(sxpElement, null, '\t')
 						}
 					/>
 
@@ -154,10 +157,9 @@ function JSONSXPElement({
 						<ClayForm.FeedbackGroup>
 							<ClayForm.FeedbackItem>
 								<ClayForm.FeedbackIndicator symbol="exclamation-full" />
-
 								{
 									error.uiConfigurationValues
-										.sxpElementTemplateJSON
+										.sxpElement
 								}
 							</ClayForm.FeedbackItem>
 						</ClayForm.FeedbackGroup>
@@ -178,7 +180,7 @@ JSONSXPElement.propTypes = {
 	prefixedId: PropTypes.string,
 	setFieldTouched: PropTypes.func,
 	setFieldValue: PropTypes.func,
-	sxpElementTemplateJSON: PropTypes.object,
+	sxpElement: PropTypes.object,
 	touched: PropTypes.object,
 	uiConfigurationValues: PropTypes.object,
 };

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/JSONSXPElement.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/JSONSXPElement.js
@@ -157,10 +157,8 @@ function JSONSXPElement({
 						<ClayForm.FeedbackGroup>
 							<ClayForm.FeedbackItem>
 								<ClayForm.FeedbackIndicator symbol="exclamation-full" />
-								{
-									error.uiConfigurationValues
-										.sxpElement
-								}
+
+								{error.uiConfigurationValues.sxpElement}
 							</ClayForm.FeedbackItem>
 						</ClayForm.FeedbackGroup>
 					)}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/JSONSXPElement.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/JSONSXPElement.js
@@ -43,10 +43,10 @@ function JSONSXPElement({
 	const [collapse, setCollapse] = useState(collapseAll);
 
 	const description = getLocalizedText(
-		sxpElementTemplateJSON.description,
+		sxpElementTemplateJSON.description_i18n,
 		locale
 	);
-	const title = getLocalizedText(sxpElementTemplateJSON.title, locale);
+	const title = getLocalizedText(sxpElementTemplateJSON.title_i18n, locale);
 
 	useEffect(() => {
 		setCollapse(collapseAll);

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/index.js
@@ -79,10 +79,10 @@ function SXPElement({
 	const [active, setActive] = useState(false);
 
 	const description = getLocalizedText(
-		sxpElementTemplateJSON.description,
+		sxpElementTemplateJSON.description_i18n,
 		locale
 	);
-	const title = getLocalizedText(sxpElementTemplateJSON.title, locale);
+	const title = getLocalizedText(sxpElementTemplateJSON.title_i18n, locale);
 
 	const fieldSets = cleanUIConfigurationJSON(uiConfigurationJSON).fieldSets;
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/index.js
@@ -24,7 +24,7 @@ import {DEFAULT_SXP_ELEMENT_ICON} from '../../utils/data';
 import {INPUT_TYPES} from '../../utils/inputTypes';
 import {
 	cleanUIConfiguration,
-	getSXPElementOutput,
+	getConfigurationEntry,
 	isDefined,
 } from '../../utils/utils';
 import {PreviewModalWithCopyDownload} from '../PreviewModal';
@@ -355,7 +355,7 @@ function SXPElement({
 								fileName="sxpElement.json"
 								size="lg"
 								text={JSON.stringify(
-									getSXPElementOutput({
+									getConfigurationEntry({
 										sxpElement,
 										uiConfigurationValues,
 									}),

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/sxp_elements/boostAllKeywordsMatch.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/sxp_elements/boostAllKeywordsMatch.js
@@ -10,77 +10,64 @@
  */
 
 export default {
-	description: 'Boost contents matching all the words in the search phrase',
 	description_i18n: {
 		en_US: 'Boost contents matching all the words in the search phrase',
 	},
 	elementDefinition: {
 		category: 'boost',
-		icon: 'thumbs-up',
-		sxpBlueprint: {
-			configuration: {
-				queryConfiguration: {
-					queryEntries: [
-						{
-							clauses: [
-								{
-									context: 'query',
-									occur: 'should',
-									query: {
-										wrapper: {
-											query: {
-												multi_match: {
-													boost:
-														'${configuration.boost}',
-													fields:
-														'${configuration.fields}',
-													operator: 'and',
-													query:
-														'${configuration.keywords}',
-													type:
-														'${configuration.type}',
-												},
+		configuration: {
+			queryConfiguration: {
+				queryEntries: [
+					{
+						clauses: [
+							{
+								context: 'query',
+								occur: 'should',
+								query: {
+									wrapper: {
+										query: {
+											multi_match: {
+												boost: '${configuration.boost}',
+												fields:
+													'${configuration.fields}',
+												operator: 'and',
+												query:
+													'${configuration.keywords}',
+												type: '${configuration.type}',
 											},
 										},
 									},
 								},
-							],
-						},
-					],
-				},
+							},
+						],
+					},
+				],
 			},
 		},
+		icon: 'thumbs-up',
 		uiConfiguration: {
 			fieldSets: [
 				{
 					fields: [
 						{
-							defaultValue: [
+							boost: true,
+							fieldMappings: [
 								{
-									boost: '2',
+									boost: 2.0,
 									field: 'localized_title',
 									locale: '${context.language_id}',
 								},
 								{
-									boost: '1',
+									boost: 1.0,
 									field: 'content',
 									locale: '${context.language_id}',
 								},
 							],
 							label: 'Field',
 							name: 'fields',
-							options: [
-								{
-									label: 'boost',
-									value: 'true',
-								},
-							],
-							type: 'fieldMappingList',
+							uiType: 'fieldMappingList',
 						},
 						{
-							defaultValue: {
-								value: 'best_fields',
-							},
 							label: 'Match Type',
 							name: 'type',
 							options: [
@@ -109,41 +96,35 @@ export default {
 									value: 'bool_prefix',
 								},
 							],
-							type: 'select',
+							uiType: 'select',
+							valueDefinition: {
+								defaultValueString: 'best_fields',
+								type: 'String',
+							},
 						},
 						{
-							defaultValue: {
-								value: '10',
-							},
 							label: 'Boost',
 							name: 'boost',
-							options: [
-								{
-									label: 'min',
-									value: '0',
-								},
-							],
-							type: 'number',
+							uiType: 'number',
+							valueDefinition: {
+								defaultValueInteger: 10,
+								minValueInteger: 0,
+								type: 'Integer',
+							},
 						},
 						{
 							helpText:
 								'If this is set, the search terms entered in the search bar will be replaced by this value.',
 							label: 'Text to Match',
 							name: 'keywords',
-							options: [
-								{
-									label: 'required',
-									value: 'false',
-								},
-							],
-							type: 'keywords',
+							required: 'false',
+							uiType: 'keywords',
 						},
 					],
 				},
 			],
 		},
 	},
-	title: 'Boost All Keywords Match',
 	title_i18n: {
 		en_US: 'Boost All Keywords Match',
 	},

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/sxp_elements/pasteAnyElasticsearchQuery.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/sxp_elements/pasteAnyElasticsearchQuery.js
@@ -10,42 +10,36 @@
  */
 
 export default {
-	description: 'Paste any Elasticsearch query body in the element as is',
 	description_i18n: {
-		en_US: 'Paste any Elasticsearch query body in the element as is',
+		en_US: 'Paste any Elasticsearch query body in the element as is.',
 	},
 	elementDefinition: {
 		category: 'custom',
-		icon: 'custom-field',
-		sxpBlueprint: {
-			configuration: {
-				queryConfiguration: {
-					queryEntries: [
-						{
-							clauses: [
-								{
-									context: 'query',
-									occur: '${configuration.occur}',
-									query: {
-										wrapper: {
-											query: '${configuration.query}',
-										},
+		configuration: {
+			queryConfiguration: {
+				queryEntries: [
+					{
+						clauses: [
+							{
+								context: 'query',
+								occur: '${configuration.occur}',
+								query: {
+									wrapper: {
+										query: '${configuration.query}',
 									},
 								},
-							],
-						},
-					],
-				},
+							},
+						],
+					},
+				],
 			},
 		},
+		icon: 'custom-field',
 		uiConfiguration: {
 			fieldSets: [
 				{
 					fields: [
 						{
-							defaultValue: {
-								value: 'must',
-							},
 							label: 'Occur',
 							name: 'occur',
 							options: [
@@ -66,20 +60,23 @@ export default {
 									value: 'filter',
 								},
 							],
-							type: 'select',
+							uiType: 'select',
+							valueDefinition: {
+								defaultValueString: 'must',
+								type: 'String',
+							},
 						},
 						{
 							label: 'Query',
 							name: 'query',
-							type: 'json',
+							uiType: 'json',
 						},
 					],
 				},
 			],
 		},
 	},
-	title: 'Paste any Elasticsearch query',
 	title_i18n: {
-		en_US: 'Paste any Elasticsearch query',
+		en_US: 'Paste Any Elasticsearch Query',
 	},
 };

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/constants.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/constants.js
@@ -25,3 +25,4 @@ export const DEFAULT_ERROR = Liferay.Language.get(
 export const SXP_ELEMENT_PREFIX = {
 	QUERY: 'querySXPElement',
 };
+export const SXP_ELEMENT_TYPE = {QUERY: 10};

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/data.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/data.js
@@ -21,19 +21,15 @@ import boostAllKeywordsMatch from '../sxp_elements/boostAllKeywordsMatch';
 // import TEXT_MATCH_OVER_MULTIPLE_FIELDS from '../sxp_elements/textMatchOverMultipleFields';
 
 export const CUSTOM_JSON_SXP_ELEMENT = {
-	sxpElementTemplateJSON: {
-		category: 'custom',
-		clauses: [],
-		conditions: {},
-		description: Liferay.Language.get('editable-json-text-area'),
-		description_i18n: {
-			en_US: Liferay.Language.get('editable-json-text-area'),
-		},
-		enabled: true,
-		icon: 'custom-field',
-		title: Liferay.Language.get('custom-json-element'),
-		title_i18n: {en_US: Liferay.Language.get('custom-json-element')},
+	description_i18n: {
+		en_US: Liferay.Language.get('editable-json-text-area'),
 	},
+	elementDefinition: {
+		category: 'custom',
+		configuration: {},
+		icon: 'custom-field',
+	},
+	title_i18n: {en_US: Liferay.Language.get('custom-json-element')},
 };
 
 export const DEFAULT_ADVANCED_CONFIGURATION = {};

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
@@ -544,36 +544,35 @@ export function getUIConfigurationValues(uiConfigurationJSON) {
 }
 
 /**
- * Function for getting formatting SXP element into expected sxpElementTemplateJSON,
+ * Function for formatting SXP element into expected sxpElementTemplateJSON,
  * uiConfigurationJSON, and uiConfigurationValues.
  *
  * @param {object} querySXPElement Object of SXP Element from REST API
  * @return {object}
  */
-export function getSXPBlueprintForm({
-	description,
-	description_i18n,
-	elementDefinition,
+export const getSXPBlueprintForm = ({
 	title,
+	description,
 	title_i18n,
-}) {
+	description_i18n,
+	elementDefinition = {},
+}) => {
+	const {uiConfiguration, ...restOfElementDefinition} = elementDefinition;
+
 	return {
 		sxpElementTemplateJSON: {
-			category: elementDefinition?.category,
-			description,
-			description_i18n,
-			icon: elementDefinition?.icon,
-			...elementDefinition?.sxpBlueprint?.configuration
-				?.queryConfiguration?.queryEntries[0],
-			title,
-			title_i18n,
+			description_i18n: description_i18n || {
+				[Liferay.ThemeDisplay.getDefaultLanguageId()]: description,
+			},
+			title_i18n: title_i18n || {
+				[Liferay.ThemeDisplay.getDefaultLanguageId()]: title,
+			},
+			...restOfElementDefinition,
 		},
-		uiConfigurationJSON: elementDefinition?.uiConfiguration || {},
-		uiConfigurationValues: getUIConfigurationValues(
-			elementDefinition?.uiConfiguration
-		),
+		uiConfigurationJSON: uiConfiguration,
+		uiConfigurationValues: getUIConfigurationValues(uiConfiguration),
 	};
-}
+};
 
 /**
  * Function for transforming the framework configuration's `clause_contributor`

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
@@ -290,10 +290,7 @@ export function getDefaultValue(item) {
  * @param {object} _.uiConfigurationValues Values that will replace the keys in uiConfiguration
  * @return {object}
  */
-export function getConfigurationEntry({
-	sxpElement,
-	uiConfigurationValues,
-}) {
+export function getConfigurationEntry({sxpElement, uiConfigurationValues}) {
 	const fieldSets = cleanUIConfiguration(
 		sxpElement.elementDefinition?.uiConfiguration
 	).fieldSets;
@@ -485,7 +482,7 @@ export function getConfigurationEntry({
 		parseCustomSXPElement(sxpElement, uiConfigurationValues)
 			.elementDefinition?.configuration || {}
 	);
-};
+}
 
 /**
  * Function for parsing custom json element text into sxpElement
@@ -494,7 +491,7 @@ export function getConfigurationEntry({
  * @param {object} uiConfigurationValues Contains custom JSON for sxpElement
  * @return {object}
  */
-export const parseCustomSXPElement = (sxpElement, uiConfigurationValues) => {
+export function parseCustomSXPElement(sxpElement, uiConfigurationValues) {
 	try {
 		if (isDefined(uiConfigurationValues.sxpElement)) {
 			return JSON.parse(uiConfigurationValues.sxpElement);

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
@@ -290,11 +290,13 @@ export function getDefaultValue(item) {
  * @param {object} _.uiConfigurationValues Values that will replace the keys in uiConfiguration
  * @return {object}
  */
-export function getSXPElementOutput({
+export function getConfigurationEntry({
 	sxpElement,
 	uiConfigurationValues,
 }) {
-	const fieldSets = cleanUIConfiguration(sxpElement.elementDefinition?.uiConfiguration).fieldSets;
+	const fieldSets = cleanUIConfiguration(
+		sxpElement.elementDefinition?.uiConfiguration
+	).fieldSets;
 
 	if (fieldSets.length > 0) {
 		let flattenJSON = JSON.stringify(

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
@@ -558,37 +558,6 @@ export function getUIConfigurationValues(uiConfiguration = {}) {
 }
 
 /**
- * Function for formatting SXP element into expected sxpElementTemplateJSON,
- * uiConfigurationJSON, and uiConfigurationValues.
- *
- * @param {object} querySXPElement Object of SXP Element from REST API
- * @return {object}
- */
-export const getSXPBlueprintForm = ({
-	title,
-	description,
-	title_i18n,
-	description_i18n,
-	elementDefinition = {},
-}) => {
-	const {uiConfiguration, ...restOfElementDefinition} = elementDefinition;
-
-	return {
-		sxpElementTemplateJSON: {
-			description_i18n: description_i18n || {
-				[Liferay.ThemeDisplay.getDefaultLanguageId()]: description,
-			},
-			title_i18n: title_i18n || {
-				[Liferay.ThemeDisplay.getDefaultLanguageId()]: title,
-			},
-			...restOfElementDefinition,
-		},
-		uiConfigurationJSON: uiConfiguration,
-		uiConfigurationValues: getUIConfigurationValues(uiConfiguration),
-	};
-};
-
-/**
  * Function for transforming the framework configuration's `clause_contributor`
  * object to an object of clause contributors with `enabled` state.
  *

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/view_sxp_blueprints/AddSXPBlueprintModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/view_sxp_blueprints/AddSXPBlueprintModal.js
@@ -20,7 +20,7 @@ import getCN from 'classnames';
 import {fetch, navigate} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
-import {DEFAULT_ERROR} from '../utils/constants';
+import {DEFAULT_ERROR, SXP_ELEMENT_TYPE} from '../utils/constants';
 import {
 	BASELINE_CLAUSE_CONTRIBUTORS_CONFIGURATION,
 	DEFAULT_ADVANCED_CONFIGURATION,
@@ -34,7 +34,16 @@ import {FRAMEWORK_TYPES} from '../utils/frameworkTypes';
 import {getSXPBlueprintForm, getSXPElementOutput} from '../utils/utils';
 
 const DEFAULT_SELECTED_BASELINE_SXP_ELEMENTS = DEFAULT_BASELINE_SXP_ELEMENTS.map(
-	getSXPBlueprintForm
+	(sxpElement) => {
+		const translatedSXPElement = getSXPBlueprintForm(sxpElement);
+
+		return {
+			configurationEntry: getSXPElementOutput(translatedSXPElement),
+			sxpElement,
+			type: sxpElement.type || SXP_ELEMENT_TYPE.QUERY,
+			uiConfigurationValues: translatedSXPElement.uiConfigurationValues,
+		};
+	}
 );
 
 const FrameworkCard = ({
@@ -141,12 +150,6 @@ const AddModal = ({
 		parameters: DEFAULT_PARAMETER_CONFIGURATION,
 		queryConfiguration: {
 			applyIndexerClauses: framework === FRAMEWORK_TYPES.ALL,
-			queryEntries:
-				framework === FRAMEWORK_TYPES.BASELINE
-					? DEFAULT_SELECTED_BASELINE_SXP_ELEMENTS.map(
-							getSXPElementOutput
-					  )
-					: [],
 		},
 		sortConfiguration: DEFAULT_SORT_CONFIGURATION,
 	});
@@ -158,14 +161,10 @@ const AddModal = ({
 			body: JSON.stringify({
 				configuration: _getConfiguration(),
 				description_i18n: {[defaultLocale]: descriptionInputValue},
-				elementInstances: {
-					queryConfiguration: {
-						queryEntries:
-							framework === FRAMEWORK_TYPES.BASELINE
-								? DEFAULT_SELECTED_BASELINE_SXP_ELEMENTS
-								: [],
-					},
-				},
+				elementInstances:
+					framework === FRAMEWORK_TYPES.BASELINE
+						? DEFAULT_SELECTED_BASELINE_SXP_ELEMENTS
+						: [],
 				title_i18n: {[defaultLocale]: inputValue},
 			}),
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/view_sxp_blueprints/AddSXPBlueprintModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/view_sxp_blueprints/AddSXPBlueprintModal.js
@@ -31,17 +31,22 @@ import {
 } from '../utils/data';
 import {fetchData} from '../utils/fetch';
 import {FRAMEWORK_TYPES} from '../utils/frameworkTypes';
-import {getSXPBlueprintForm, getSXPElementOutput} from '../utils/utils';
+import {getSXPElementOutput, getUIConfigurationValues} from '../utils/utils';
 
 const DEFAULT_SELECTED_BASELINE_SXP_ELEMENTS = DEFAULT_BASELINE_SXP_ELEMENTS.map(
 	(sxpElement) => {
-		const translatedSXPElement = getSXPBlueprintForm(sxpElement);
+		const uiConfigurationValues = getUIConfigurationValues(
+			sxpElement.elementDefinition?.uiConfiguration
+		);
 
 		return {
-			configurationEntry: getSXPElementOutput(translatedSXPElement),
+			configurationEntry: getSXPElementOutput({
+				sxpElement,
+				uiConfigurationValues,
+			}),
 			sxpElement,
 			type: sxpElement.type || SXP_ELEMENT_TYPE.QUERY,
-			uiConfigurationValues: translatedSXPElement.uiConfigurationValues,
+			uiConfigurationValues,
 		};
 	}
 );

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/view_sxp_blueprints/AddSXPBlueprintModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/view_sxp_blueprints/AddSXPBlueprintModal.js
@@ -31,7 +31,7 @@ import {
 } from '../utils/data';
 import {fetchData} from '../utils/fetch';
 import {FRAMEWORK_TYPES} from '../utils/frameworkTypes';
-import {getSXPElementOutput, getUIConfigurationValues} from '../utils/utils';
+import {getConfigurationEntry, getUIConfigurationValues} from '../utils/utils';
 
 const DEFAULT_SELECTED_BASELINE_SXP_ELEMENTS = DEFAULT_BASELINE_SXP_ELEMENTS.map(
 	(sxpElement) => {
@@ -40,7 +40,7 @@ const DEFAULT_SELECTED_BASELINE_SXP_ELEMENTS = DEFAULT_BASELINE_SXP_ELEMENTS.map
 		);
 
 		return {
-			configurationEntry: getSXPElementOutput({
+			configurationEntry: getConfigurationEntry({
 				sxpElement,
 				uiConfigurationValues,
 			}),

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -14,11 +14,11 @@ import React from 'react';
 
 import EditSXPBlueprintForm from '../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm';
 const Toasts = require('../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/toasts');
-import {getSXPElementOutput} from '../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils';
+import {getUIConfigurationValues} from '../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils';
 import {
 	ENTITY_JSON,
 	INITIAL_CONFIGURATION,
-	SELECTED_SXP_ELEMENTS,
+	QUERY_SXP_ELEMENTS,
 } from '../mocks/data';
 
 import '@testing-library/jest-dom/extend-expect';
@@ -61,9 +61,7 @@ function renderEditSXPBlueprintForm(props) {
 			entityJSON={ENTITY_JSON}
 			initialConfiguration={INITIAL_CONFIGURATION}
 			initialDescription={{}}
-			initialSXPElementInstances={{
-				queryConfiguration: {queryEntries: []},
-			}}
+			initialSXPElementInstances={[]}
 			initialTitle={{
 				en_US: 'Test Title',
 			}}
@@ -84,26 +82,23 @@ describe('EditSXPBlueprintForm', () => {
 
 	it('renders the query elements', async () => {
 		const {container, findByText} = renderEditSXPBlueprintForm({
-			initialConfiguration: {
-				...INITIAL_CONFIGURATION,
-				queryConfiguration: {
-					applyIndexerClauses: true,
-					queryEntries: SELECTED_SXP_ELEMENTS.map(
-						getSXPElementOutput
+			initialSXPElementInstances: QUERY_SXP_ELEMENTS.map(
+				(sxpElement) => ({
+					sxpElement,
+					type: 10,
+					uiConfigurationValues: getUIConfigurationValues(
+						sxpElement.elementDefinition.uiConfiguration
 					),
-				},
-			},
-			initialSXPElementInstances: {
-				queryConfiguration: {queryEntries: SELECTED_SXP_ELEMENTS},
-			},
+				})
+			),
 		});
 
 		await findByText('query-settings');
 
 		const {getByText} = within(container.querySelector('.builder'));
 
-		SELECTED_SXP_ELEMENTS.map((sxpElement) =>
-			getByText(sxpElement.sxpElementTemplateJSON.title_i18n['en_US'])
+		QUERY_SXP_ELEMENTS.map((sxpElement) =>
+			getByText(sxpElement.title_i18n['en_US'])
 		);
 	});
 
@@ -138,18 +133,15 @@ describe('EditSXPBlueprintForm', () => {
 			getAllByLabelText,
 			getAllByText,
 		} = renderEditSXPBlueprintForm({
-			initialConfiguration: {
-				...INITIAL_CONFIGURATION,
-				queryConfiguration: {
-					applyIndexerClauses: true,
-					queryEntries: SELECTED_SXP_ELEMENTS.map(
-						getSXPElementOutput
+			initialSXPElementInstances: QUERY_SXP_ELEMENTS.map(
+				(sxpElement) => ({
+					sxpElement,
+					type: 10,
+					uiConfigurationValues: getUIConfigurationValues(
+						sxpElement.elementDefinition.uiConfiguration
 					),
-				},
-			},
-			initialSXPElementInstances: {
-				queryConfiguration: {queryEntries: SELECTED_SXP_ELEMENTS},
-			},
+				})
+			),
 		});
 
 		await findByText('query-settings');

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/query_builder_tab/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/query_builder_tab/index.js
@@ -13,9 +13,11 @@ import {fireEvent, render} from '@testing-library/react';
 import React from 'react';
 
 import QueryBuilder from '../../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab';
-import {SELECTED_SXP_ELEMENTS} from '../../mocks/data';
+import {QUERY_SXP_ELEMENTS} from '../../mocks/data';
 
 import '@testing-library/jest-dom/extend-expect';
+
+import {getUIConfigurationValues} from '../../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils';
 
 jest.mock(
 	'../../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor',
@@ -46,11 +48,15 @@ afterAll(() => {
 function renderBuilder(props) {
 	return render(
 		<QueryBuilder
+			elementInstances={QUERY_SXP_ELEMENTS.map((sxpElement, index) => ({
+				id: index,
+				sxpElement,
+				uiConfigurationValues: getUIConfigurationValues(
+					sxpElement.elementDefinition.uiConfiguration
+				),
+			}))}
 			onDeleteSXPElement={jest.fn()}
 			onFrameworkConfigChange={jest.fn()}
-			selectedSXPElements={SELECTED_SXP_ELEMENTS.map(
-				(element, index) => ({...element, id: index})
-			)}
 			{...props}
 		/>
 	);
@@ -70,8 +76,8 @@ describe('QueryBuilder', () => {
 
 		await findByText('query-builder');
 
-		SELECTED_SXP_ELEMENTS.map((sxpElement) =>
-			getByText(sxpElement.sxpElementTemplateJSON.title_i18n['en_US'])
+		QUERY_SXP_ELEMENTS.map((sxpElement) =>
+			getByText(sxpElement.title_i18n['en_US'])
 		);
 	});
 
@@ -80,10 +86,8 @@ describe('QueryBuilder', () => {
 
 		await findByText('query-builder');
 
-		SELECTED_SXP_ELEMENTS.map((sxpElement) =>
-			getByText(
-				sxpElement.sxpElementTemplateJSON.description_i18n['en_US']
-			)
+		QUERY_SXP_ELEMENTS.map((sxpElement) =>
+			getByText(sxpElement.description_i18n['en_US'])
 		);
 	});
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/mocks/data.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/mocks/data.js
@@ -17,7 +17,6 @@ import {
 	DEFAULT_PARAMETER_CONFIGURATION,
 	DEFAULT_SORT_CONFIGURATION,
 } from '../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/data';
-import {getSXPBlueprintForm} from '../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils';
 
 export const ENTITY_JSON = {
 	'com.liferay.asset.kernel.model.AssetTag': {
@@ -114,10 +113,6 @@ export const QUERY_SXP_ELEMENTS = [
 	boostAllKeywordsMatch,
 	pasteAnyElasticsearchQuery,
 ];
-
-export const SELECTED_SXP_ELEMENTS = QUERY_SXP_ELEMENTS.map(
-	getSXPBlueprintForm
-);
 
 export const INITIAL_CONFIGURATION = {
 	advanced: DEFAULT_ADVANCED_CONFIGURATION,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/mocks/fetch.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/mocks/fetch.js
@@ -13,34 +13,12 @@ import {INDEX_FIELDS, QUERY_SXP_ELEMENTS, mockClassNames} from './data';
 
 async function mockFetch(url) {
 	switch (url) {
-		case '/o/search-experiences-rest/v1.0/sxp-elements': {
-			return {
-				json: async () => ({
-					items: QUERY_SXP_ELEMENTS,
-					page: 1,
-					totalCount: QUERY_SXP_ELEMENTS.length,
-				}),
-				ok: true,
-				status: 200,
-			};
-		}
 		case '/o/search-experiences-rest/v1.0/field-mapping-infos': {
 			return {
 				json: async () => ({
 					items: INDEX_FIELDS,
 					page: 1,
 					totalCount: INDEX_FIELDS.length,
-				}),
-				ok: true,
-				status: 200,
-			};
-		}
-		case '/o/search-experiences-rest/v1.0/searchable-asset-names/en_US': {
-			return {
-				json: async () => ({
-					items: mockClassNames('SearchableAssetType'),
-					page: 1,
-					totalCount: 10,
 				}),
 				ok: true,
 				status: 200,
@@ -74,6 +52,28 @@ async function mockFetch(url) {
 					items: mockClassNames('QueryPrefilterContributor'),
 					page: 1,
 					totalCount: 10,
+				}),
+				ok: true,
+				status: 200,
+			};
+		}
+		case '/o/search-experiences-rest/v1.0/searchable-asset-names/en_US': {
+			return {
+				json: async () => ({
+					items: mockClassNames('SearchableAssetType'),
+					page: 1,
+					totalCount: 10,
+				}),
+				ok: true,
+				status: 200,
+			};
+		}
+		case '/o/search-experiences-rest/v1.0/sxp-elements': {
+			return {
+				json: async () => ({
+					items: QUERY_SXP_ELEMENTS,
+					page: 1,
+					totalCount: QUERY_SXP_ELEMENTS.length,
 				}),
 				ok: true,
 				status: 200,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/shared/JSONSXPElement.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/shared/JSONSXPElement.js
@@ -13,7 +13,7 @@ import {fireEvent, render} from '@testing-library/react';
 import React from 'react';
 
 import JSONSXPElement from '../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/JSONSXPElement';
-import {SELECTED_SXP_ELEMENTS} from '../mocks/data';
+import {QUERY_SXP_ELEMENTS} from '../mocks/data';
 
 import '@testing-library/jest-dom/extend-expect';
 
@@ -36,9 +36,7 @@ function renderJSONSXPElement(props) {
 			onDeleteSXPElement={onDeleteSXPElement}
 			setFieldTouched={setFieldTouched}
 			setFieldValue={setFieldValue}
-			sxpElementTemplateJSON={
-				SELECTED_SXP_ELEMENTS[0].sxpElementTemplateJSON
-			}
+			sxpElement={QUERY_SXP_ELEMENTS[0]}
 			{...props}
 		/>
 	);
@@ -54,19 +52,13 @@ describe('JSONSXPElement', () => {
 	it('displays the title', () => {
 		const {getByText} = renderJSONSXPElement();
 
-		getByText(
-			SELECTED_SXP_ELEMENTS[0].sxpElementTemplateJSON.title_i18n['en_US']
-		);
+		getByText(QUERY_SXP_ELEMENTS[0].title_i18n['en_US']);
 	});
 
 	it('displays the description', () => {
 		const {getByText} = renderJSONSXPElement();
 
-		getByText(
-			SELECTED_SXP_ELEMENTS[0].sxpElementTemplateJSON.description_i18n[
-				'en_US'
-			]
-		);
+		getByText(QUERY_SXP_ELEMENTS[0].description_i18n['en_US']);
 	});
 
 	it('can collapse the query elements', () => {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/shared/sxp_element/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/shared/sxp_element/index.js
@@ -13,7 +13,8 @@ import {fireEvent, render} from '@testing-library/react';
 import React from 'react';
 
 import SXPElement from '../../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/index';
-import {INDEX_FIELDS, SELECTED_SXP_ELEMENTS} from '../../mocks/data';
+import {getUIConfigurationValues} from '../../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils';
+import {INDEX_FIELDS, QUERY_SXP_ELEMENTS} from '../../mocks/data';
 
 import '@testing-library/jest-dom/extend-expect';
 
@@ -32,13 +33,10 @@ function renderSXPElement(props) {
 			collapseAll={false}
 			indexFields={INDEX_FIELDS}
 			onDeleteSXPElement={onDeleteSXPElement}
-			sxpElementTemplateJSON={
-				SELECTED_SXP_ELEMENTS[0].sxpElementTemplateJSON
-			}
-			uiConfigurationJSON={SELECTED_SXP_ELEMENTS[0].uiConfigurationJSON}
-			uiConfigurationValues={
-				SELECTED_SXP_ELEMENTS[0].uiConfigurationValues
-			}
+			sxpElement={QUERY_SXP_ELEMENTS[0]}
+			uiConfigurationValues={getUIConfigurationValues(
+				QUERY_SXP_ELEMENTS[0].elementDefinition?.uiConfiguration
+			)}
 			{...props}
 		/>
 	);
@@ -56,19 +54,13 @@ describe('SXPElement', () => {
 	it('displays the title', () => {
 		const {getByText} = renderSXPElement();
 
-		getByText(
-			SELECTED_SXP_ELEMENTS[0].sxpElementTemplateJSON.title_i18n['en_US']
-		);
+		getByText(QUERY_SXP_ELEMENTS[0].title_i18n['en_US']);
 	});
 
 	it('displays the description', () => {
 		const {getByText} = renderSXPElement();
 
-		getByText(
-			SELECTED_SXP_ELEMENTS[0].sxpElementTemplateJSON.description_i18n[
-				'en_US'
-			]
-		);
+		getByText(QUERY_SXP_ELEMENTS[0].description_i18n['en_US']);
 	});
 
 	it('can collapse the query elements', () => {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/utils/utils.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/utils/utils.js
@@ -14,8 +14,8 @@ import {
 	cleanUIConfiguration,
 	getClauseContributorsConfig,
 	getClauseContributorsState,
+	getConfigurationEntry,
 	getDefaultValue,
-	getSXPElementOutput,
 	getUIConfigurationValues,
 	isDefined,
 	isEmpty,
@@ -710,10 +710,10 @@ describe('utils', () => {
 		});
 	});
 
-	describe('getSXPElementOutput', () => {
-		it('gets sxpElementOutput of date', () => {
+	describe('getConfigurationEntry', () => {
+		it('gets configurationEntry of date', () => {
 			expect(
-				getSXPElementOutput({
+				getConfigurationEntry({
 					sxpElement: {
 						elementDefinition: {
 							configuration: {
@@ -746,9 +746,9 @@ describe('utils', () => {
 			});
 		});
 
-		it('gets sxpElementOutput of select', () => {
+		it('gets configurationEntry of select', () => {
 			expect(
-				getSXPElementOutput({
+				getConfigurationEntry({
 					sxpElement: {
 						elementDefinition: {
 							configuration: {
@@ -801,9 +801,9 @@ describe('utils', () => {
 			});
 		});
 
-		it('gets sxpElementOutput of itemSelector', () => {
+		it('gets configurationEntry of itemSelector', () => {
 			expect(
-				getSXPElementOutput({
+				getConfigurationEntry({
 					sxpElement: {
 						elementDefinition: {
 							configuration: {
@@ -837,9 +837,9 @@ describe('utils', () => {
 			});
 		});
 
-		it('gets sxpElementOutput of multiselect', () => {
+		it('gets configurationEntry of multiselect', () => {
 			expect(
-				getSXPElementOutput({
+				getConfigurationEntry({
 					sxpElement: {
 						elementDefinition: {
 							configuration: {
@@ -870,9 +870,9 @@ describe('utils', () => {
 			});
 		});
 
-		it('gets sxpElementOutput of number', () => {
+		it('gets configurationEntry of number', () => {
 			expect(
-				getSXPElementOutput({
+				getConfigurationEntry({
 					sxpElement: {
 						elementDefinition: {
 							configuration: {
@@ -903,9 +903,9 @@ describe('utils', () => {
 			});
 		});
 
-		it('gets sxpElementOutput of number with suffix', () => {
+		it('gets configurationEntry of number with suffix', () => {
 			expect(
-				getSXPElementOutput({
+				getConfigurationEntry({
 					sxpElement: {
 						elementDefinition: {
 							configuration: {
@@ -940,9 +940,9 @@ describe('utils', () => {
 			});
 		});
 
-		it('gets sxpElementOutput of slider', () => {
+		it('gets configurationEntry of slider', () => {
 			expect(
-				getSXPElementOutput({
+				getConfigurationEntry({
 					sxpElement: {
 						elementDefinition: {
 							configuration: {
@@ -973,9 +973,9 @@ describe('utils', () => {
 			});
 		});
 
-		it('gets sxpElementOutput of field mapping', () => {
+		it('gets configurationEntry of field mapping', () => {
 			expect(
-				getSXPElementOutput({
+				getConfigurationEntry({
 					sxpElement: {
 						elementDefinition: {
 							configuration: {
@@ -1013,9 +1013,9 @@ describe('utils', () => {
 			});
 		});
 
-		it('gets sxpElementOutput of field mapping list', () => {
+		it('gets configurationEntry of field mapping list', () => {
 			expect(
-				getSXPElementOutput({
+				getConfigurationEntry({
 					sxpElement: {
 						elementDefinition: {
 							configuration: {
@@ -1077,9 +1077,9 @@ describe('utils', () => {
 			});
 		});
 
-		it('gets sxpElementOutput of json', () => {
+		it('gets configurationEntry of json', () => {
 			expect(
-				getSXPElementOutput({
+				getConfigurationEntry({
 					sxpElement: {
 						elementDefinition: {
 							configuration: {
@@ -1109,9 +1109,9 @@ describe('utils', () => {
 			});
 		});
 
-		it('gets sxpElementOutput of text', () => {
+		it('gets configurationEntry of text', () => {
 			expect(
-				getSXPElementOutput({
+				getConfigurationEntry({
 					sxpElement: {
 						elementDefinition: {
 							configuration: {
@@ -1146,9 +1146,9 @@ describe('utils', () => {
 			});
 		});
 
-		it('gets sxpElementOutput of configuration with multiple fields', () => {
+		it('gets configurationEntry of configuration with multiple fields', () => {
 			expect(
-				getSXPElementOutput({
+				getConfigurationEntry({
 					sxpElement: {
 						elementDefinition: {
 							configuration: {
@@ -1207,9 +1207,9 @@ describe('utils', () => {
 			});
 		});
 
-		it('gets sxpElementOutput of custom json with no configuration', () => {
+		it('gets configurationEntry of custom json with no configuration', () => {
 			expect(
-				getSXPElementOutput({
+				getConfigurationEntry({
 					sxpElement: {
 						description_i18n: {en_US: 'Editable JSON text area'},
 						elementDefinition: {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/utils/utils.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/utils/utils.js
@@ -11,7 +11,7 @@
 
 import {INPUT_TYPES} from '../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/inputTypes';
 import {
-	cleanUIConfigurationJSON,
+	cleanUIConfiguration,
 	getClauseContributorsConfig,
 	getClauseContributorsState,
 	getDefaultValue,
@@ -103,10 +103,10 @@ describe('utils', () => {
 		});
 	});
 
-	describe('cleanUIConfigurationJSON', () => {
+	describe('cleanUIConfiguration', () => {
 		it('returns a valid UIConfigurationJSON', () => {
 			expect(
-				cleanUIConfigurationJSON({
+				cleanUIConfiguration({
 					fieldSets: [
 						{
 							fields: [
@@ -148,7 +148,7 @@ describe('utils', () => {
 
 		it('cleans up UIConfigurationJSON when "fields" is an empty array', () => {
 			expect(
-				cleanUIConfigurationJSON({
+				cleanUIConfiguration({
 					fieldSets: [
 						{
 							fields: [],
@@ -160,7 +160,7 @@ describe('utils', () => {
 
 		it('returns a valid UIConfigurationJSON when "fieldSets" is an invalid type', () => {
 			expect(
-				cleanUIConfigurationJSON({
+				cleanUIConfiguration({
 					fieldSets: '',
 				})
 			).toEqual({fieldSets: []});
@@ -168,7 +168,7 @@ describe('utils', () => {
 
 		it('returns a valid UIConfigurationJSON when "fields" is an invalid type', () => {
 			expect(
-				cleanUIConfigurationJSON({
+				cleanUIConfiguration({
 					fieldSets: [
 						{
 							fields: '',
@@ -180,7 +180,7 @@ describe('utils', () => {
 
 		it('removes field with missing "name" property from UIConfigurationJSON', () => {
 			expect(
-				cleanUIConfigurationJSON({
+				cleanUIConfiguration({
 					fieldSets: [
 						{
 							fields: [
@@ -216,7 +216,7 @@ describe('utils', () => {
 
 		it('removes field with non-unique "name" property from UIConfigurationJSON', () => {
 			expect(
-				cleanUIConfigurationJSON({
+				cleanUIConfiguration({
 					fieldSets: [
 						{
 							fields: [
@@ -714,24 +714,28 @@ describe('utils', () => {
 		it('gets sxpElementOutput of date', () => {
 			expect(
 				getSXPElementOutput({
-					sxpElementTemplateJSON: {
-						start_date: '${configuration.start_date}',
-					},
-					uiConfigurationJSON: {
-						fieldSets: [
-							{
-								fields: [
+					sxpElement: {
+						elementDefinition: {
+							configuration: {
+								start_date: '${configuration.start_date}',
+							},
+							uiConfiguration: {
+								fieldSets: [
 									{
-										label: 'Create Date: From',
-										name: 'start_date',
-										type: 'date',
-										typeOptions: {
-											format: 'YYYYMMDD',
-										},
+										fields: [
+											{
+												label: 'Create Date: From',
+												name: 'start_date',
+												type: 'date',
+												typeOptions: {
+													format: 'YYYYMMDD',
+												},
+											},
+										],
 									},
 								],
 							},
-						],
+						},
 					},
 					uiConfigurationValues: {
 						start_date: 1609488000,
@@ -745,38 +749,48 @@ describe('utils', () => {
 		it('gets sxpElementOutput of select', () => {
 			expect(
 				getSXPElementOutput({
-					sxpElementTemplateJSON: {
-						type: '${configuration.type}',
-					},
-					uiConfigurationJSON: {
-						fieldSets: [
-							{
-								fields: [
+					sxpElement: {
+						elementDefinition: {
+							configuration: {
+								type: '${configuration.type}',
+							},
+							uiConfiguration: {
+								fieldSets: [
 									{
-										defaultValue: 'best_fields',
-										label: 'Match Type',
-										name: 'type',
-										type: 'select',
-										typeOptions: {
-											options: [
-												{
-													label: 'Best Fields',
-													value: 'best_fields',
+										fields: [
+											{
+												defaultValue: 'best_fields',
+												label: 'Match Type',
+												name: 'type',
+												type: 'select',
+												typeOptions: {
+													options: [
+														{
+															label:
+																'Best Fields',
+															value:
+																'best_fields',
+														},
+														{
+															label:
+																'Most Fields',
+															value:
+																'most_fields',
+														},
+														{
+															label:
+																'Cross Fields',
+															value:
+																'cross_fields',
+														},
+													],
 												},
-												{
-													label: 'Most Fields',
-													value: 'most_fields',
-												},
-												{
-													label: 'Cross Fields',
-													value: 'cross_fields',
-												},
-											],
-										},
+											},
+										],
 									},
 								],
 							},
-						],
+						},
 					},
 					uiConfigurationValues: {
 						type: 'best_fields',
@@ -790,25 +804,29 @@ describe('utils', () => {
 		it('gets sxpElementOutput of itemSelector', () => {
 			expect(
 				getSXPElementOutput({
-					sxpElementTemplateJSON: {
-						role: '${configuration.role_id}',
-					},
-					uiConfigurationJSON: {
-						fieldSets: [
-							{
-								fields: [
+					sxpElement: {
+						elementDefinition: {
+							configuration: {
+								role: '${configuration.role_id}',
+							},
+							uiConfiguration: {
+								fieldSets: [
 									{
-										label: 'Role',
-										name: 'role_id',
-										type: 'itemSelector',
-										typeOptions: {
-											itemType:
-												'com.liferay.portal.kernel.model.Role',
-										},
+										fields: [
+											{
+												label: 'Role',
+												name: 'role_id',
+												type: 'itemSelector',
+												typeOptions: {
+													itemType:
+														'com.liferay.portal.kernel.model.Role',
+												},
+											},
+										],
 									},
 								],
 							},
-						],
+						},
 					},
 					uiConfigurationValues: {
 						role_id: [{label: 'Administrator', value: '20107'}],
@@ -822,22 +840,26 @@ describe('utils', () => {
 		it('gets sxpElementOutput of multiselect', () => {
 			expect(
 				getSXPElementOutput({
-					sxpElementTemplateJSON: {
-						keywords: '${configuration.keywords}',
-					},
-					uiConfigurationJSON: {
-						fieldSets: [
-							{
-								fields: [
+					sxpElement: {
+						elementDefinition: {
+							configuration: {
+								keywords: '${configuration.keywords}',
+							},
+							uiConfiguration: {
+								fieldSets: [
 									{
-										defaultValue: [],
-										label: 'Keywords',
-										name: 'keywords',
-										type: 'multiselect',
+										fields: [
+											{
+												defaultValue: [],
+												label: 'Keywords',
+												name: 'keywords',
+												type: 'multiselect',
+											},
+										],
 									},
 								],
 							},
-						],
+						},
 					},
 					uiConfigurationValues: {
 						keywords: [{label: 'test', value: 'test'}],
@@ -851,21 +873,26 @@ describe('utils', () => {
 		it('gets sxpElementOutput of number', () => {
 			expect(
 				getSXPElementOutput({
-					sxpElementTemplateJSON: {
-						asset_category_id: '${configuration.asset_category_id}',
-					},
-					uiConfigurationJSON: {
-						fieldSets: [
-							{
-								fields: [
+					sxpElement: {
+						elementDefinition: {
+							configuration: {
+								asset_category_id:
+									'${configuration.asset_category_id}',
+							},
+							uiConfiguration: {
+								fieldSets: [
 									{
-										label: 'Asset Category ID',
-										name: 'asset_category_id',
-										type: 'number',
+										fields: [
+											{
+												label: 'Asset Category ID',
+												name: 'asset_category_id',
+												type: 'number',
+											},
+										],
 									},
 								],
 							},
-						],
+						},
 					},
 					uiConfigurationValues: {
 						asset_category_id: 1032490,
@@ -879,26 +906,30 @@ describe('utils', () => {
 		it('gets sxpElementOutput of number with suffix', () => {
 			expect(
 				getSXPElementOutput({
-					sxpElementTemplateJSON: {
-						time_range: '${configuration.time_range}',
-					},
-					uiConfigurationJSON: {
-						fieldSets: [
-							{
-								fields: [
+					sxpElement: {
+						elementDefinition: {
+							configuration: {
+								time_range: '${configuration.time_range}',
+							},
+							uiConfiguration: {
+								fieldSets: [
 									{
-										defaultValue: 30,
-										label: 'Time range',
-										name: 'time_range',
-										type: 'number',
-										typeOptions: {
-											unit: 'days',
-											unitSuffix: 'd',
-										},
+										fields: [
+											{
+												defaultValue: 30,
+												label: 'Time range',
+												name: 'time_range',
+												type: 'number',
+												typeOptions: {
+													unit: 'days',
+													unitSuffix: 'd',
+												},
+											},
+										],
 									},
 								],
 							},
-						],
+						},
 					},
 					uiConfigurationValues: {
 						time_range: 30,
@@ -912,22 +943,26 @@ describe('utils', () => {
 		it('gets sxpElementOutput of slider', () => {
 			expect(
 				getSXPElementOutput({
-					sxpElementTemplateJSON: {
-						boost: '${configuration.boost}',
-					},
-					uiConfigurationJSON: {
-						fieldSets: [
-							{
-								fields: [
+					sxpElement: {
+						elementDefinition: {
+							configuration: {
+								boost: '${configuration.boost}',
+							},
+							uiConfiguration: {
+								fieldSets: [
 									{
-										defaultValue: 10,
-										label: 'Boost',
-										name: 'boost',
-										type: 'slider',
+										fields: [
+											{
+												defaultValue: 10,
+												label: 'Boost',
+												name: 'boost',
+												type: 'slider',
+											},
+										],
 									},
 								],
 							},
-						],
+						},
 					},
 					uiConfigurationValues: {
 						boost: 20,
@@ -941,25 +976,29 @@ describe('utils', () => {
 		it('gets sxpElementOutput of field mapping', () => {
 			expect(
 				getSXPElementOutput({
-					sxpElementTemplateJSON: {
-						field: '${configuration.field}',
-					},
-					uiConfigurationJSON: {
-						fieldSets: [
-							{
-								fields: [
+					sxpElement: {
+						elementDefinition: {
+							configuration: {
+								field: '${configuration.field}',
+							},
+							uiConfiguration: {
+								fieldSets: [
 									{
-										defaultValue: {
-											field: '',
-											locale: '',
-										},
-										label: 'Field',
-										name: 'field',
-										type: 'fieldMapping',
+										fields: [
+											{
+												defaultValue: {
+													field: '',
+													locale: '',
+												},
+												label: 'Field',
+												name: 'field',
+												type: 'fieldMapping',
+											},
+										],
 									},
 								],
 							},
-						],
+						},
 					},
 					uiConfigurationValues: {
 						field: {
@@ -977,38 +1016,43 @@ describe('utils', () => {
 		it('gets sxpElementOutput of field mapping list', () => {
 			expect(
 				getSXPElementOutput({
-					sxpElementTemplateJSON: {
-						fields: '${configuration.fields}',
-					},
-					uiConfigurationJSON: {
-						fieldSets: [
-							{
-								fields: [
+					sxpElement: {
+						elementDefinition: {
+							configuration: {
+								fields: '${configuration.fields}',
+							},
+							uiConfiguration: {
+								fieldSets: [
 									{
-										defaultValue: [
+										fields: [
 											{
-												boost: 2,
-												field: 'localized_title',
-												locale:
-													'${context.language_id}',
-											},
-											{
-												boost: 1,
-												field: 'content',
-												locale:
-													'${context.language_id}',
+												defaultValue: [
+													{
+														boost: 2,
+														field:
+															'localized_title',
+														locale:
+															'${context.language_id}',
+													},
+													{
+														boost: 1,
+														field: 'content',
+														locale:
+															'${context.language_id}',
+													},
+												],
+												label: 'Field',
+												name: 'fields',
+												type: 'fieldMappingList',
+												typeOptions: {
+													boost: true,
+												},
 											},
 										],
-										label: 'Field',
-										name: 'fields',
-										type: 'fieldMappingList',
-										typeOptions: {
-											boost: true,
-										},
 									},
 								],
 							},
-						],
+						},
 					},
 					uiConfigurationValues: {
 						fields: [
@@ -1036,21 +1080,25 @@ describe('utils', () => {
 		it('gets sxpElementOutput of json', () => {
 			expect(
 				getSXPElementOutput({
-					sxpElementTemplateJSON: {
-						json: '${configuration.json}',
-					},
-					uiConfigurationJSON: {
-						fieldSets: [
-							{
-								fields: [
+					sxpElement: {
+						elementDefinition: {
+							configuration: {
+								json: '${configuration.json}',
+							},
+							uiConfiguration: {
+								fieldSets: [
 									{
-										defaultValue: {},
-										name: 'json',
-										type: 'json',
+										fields: [
+											{
+												defaultValue: {},
+												name: 'json',
+												type: 'json',
+											},
+										],
 									},
 								],
 							},
-						],
+						},
 					},
 					uiConfigurationValues: {
 						json: '{"category": "custom"}',
@@ -1064,24 +1112,28 @@ describe('utils', () => {
 		it('gets sxpElementOutput of text', () => {
 			expect(
 				getSXPElementOutput({
-					sxpElementTemplateJSON: {
-						geopoint: '${configuration.geopoint}',
-					},
-					uiConfigurationJSON: {
-						fieldSets: [
-							{
-								fields: [
+					sxpElement: {
+						elementDefinition: {
+							configuration: {
+								geopoint: '${configuration.geopoint}',
+							},
+							uiConfiguration: {
+								fieldSets: [
 									{
-										defaultValue:
-											'expando__keyword__custom_fields__location_geolocation',
-										helpText: 'A geopoint field',
-										label: 'Geopoint',
-										name: 'geopoint',
-										type: 'text',
+										fields: [
+											{
+												defaultValue:
+													'expando__keyword__custom_fields__location_geolocation',
+												helpText: 'A geopoint field',
+												label: 'Geopoint',
+												name: 'geopoint',
+												type: 'text',
+											},
+										],
 									},
 								],
 							},
-						],
+						},
 					},
 					uiConfigurationValues: {
 						geopoint:
@@ -1097,42 +1149,46 @@ describe('utils', () => {
 		it('gets sxpElementOutput of configuration with multiple fields', () => {
 			expect(
 				getSXPElementOutput({
-					sxpElementTemplateJSON: {
-						boost: '${configuration.boost}',
-						field: '${configuration.field}',
-						json: '${configuration.json}',
-					},
-					uiConfigurationJSON: {
-						fieldSets: [
-							{
-								fields: [
+					sxpElement: {
+						elementDefinition: {
+							configuration: {
+								boost: '${configuration.boost}',
+								field: '${configuration.field}',
+								json: '${configuration.json}',
+							},
+							uiConfiguration: {
+								fieldSets: [
 									{
-										defaultValue: 10,
-										label: 'Boost',
-										name: 'boost',
-										type: 'slider',
+										fields: [
+											{
+												defaultValue: 10,
+												label: 'Boost',
+												name: 'boost',
+												type: 'slider',
+											},
+											{
+												defaultValue: {},
+												name: 'json',
+												type: 'json',
+											},
+										],
 									},
 									{
-										defaultValue: {},
-										name: 'json',
-										type: 'json',
+										fields: [
+											{
+												defaultValue: {
+													field: '',
+													locale: '',
+												},
+												label: 'Field',
+												name: 'field',
+												type: 'fieldMapping',
+											},
+										],
 									},
 								],
 							},
-							{
-								fields: [
-									{
-										defaultValue: {
-											field: '',
-											locale: '',
-										},
-										label: 'Field',
-										name: 'field',
-										type: 'fieldMapping',
-									},
-								],
-							},
-						],
+						},
 					},
 					uiConfigurationValues: {
 						boost: 20,
@@ -1154,25 +1210,23 @@ describe('utils', () => {
 		it('gets sxpElementOutput of custom json with no configuration', () => {
 			expect(
 				getSXPElementOutput({
-					sxpElementTemplateJSON: {
-						category: 'custom',
-						clauses: [],
-						conditions: {},
-						description: 'Editable JSON text area',
-						enabled: true,
-						icon: 'custom-field',
-						title: 'Custom JSON Element',
+					sxpElement: {
+						description_i18n: {en_US: 'Editable JSON text area'},
+						elementDefinition: {
+							category: 'custom',
+							configuration: {
+								clauses: [],
+								conditions: {},
+							},
+							enabled: true,
+							icon: 'custom-field',
+						},
+						title_i18n: {en_US: 'Custom JSON Element'},
 					},
-					uiConfigurationValues: {},
 				})
 			).toEqual({
-				category: 'custom',
 				clauses: [],
 				conditions: {},
-				description: 'Editable JSON text area',
-				enabled: true,
-				icon: 'custom-field',
-				title: 'Custom JSON Element',
 			});
 		});
 	});


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-141045

Basically addressing a bunch of schema changes... I tried to organize them clearly but there were a lot of updates to the schema! 😬 Tried to follow the naming convention of the schema itself, so several variables like `selectedElements`, `sxpElementTemplateJSON`, `getElementOutput` got renamed/reworked to being the new `elementInstances`, `sxpElement`, `getConfigurationEntry`

Also included `configurationEntry`, which might be helpful for backend to work off of? If saving a blueprint with an element, it currently won't pass validation until configurationEntry is part of the schema, but at least the title and description can save 😄 for now. 

Bugs still happening:
- updates for the schema inside the uiConfiguration
- element editor still hangs after saving