### PR TITLE
LPS-145145 search-experiences-web: Render ResultListItem 

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -39,6 +39,7 @@ import {
 	isDefined,
 	parseCustomSXPElement,
 	transformToSearchContextAttributes,
+	transformToSearchPreviewHits,
 } from '../utils/utils';
 import {
 	validateBoost,
@@ -857,13 +858,13 @@ function EditSXPBlueprintForm({
 
 			<PreviewSidebar
 				errors={previewInfo.results.errors}
+				hits={transformToSearchPreviewHits(previewInfo.results)}
 				loading={previewInfo.loading}
 				onClose={_handleCloseSidebar}
 				onFetchResults={_handleFetchPreviewSearch}
 				onFocusSXPElement={_handleFocusSXPElement}
-				response={previewInfo.results.response}
 				responseString={previewInfo.results.responseString}
-				searchHits={previewInfo.results.searchHits}
+				totalHits={previewInfo.results.searchHits?.totalHits}
 				visible={openSidebar === SIDEBARS.PREVIEW}
 				warnings={previewInfo.results.warnings}
 			/>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -861,8 +861,9 @@ function EditSXPBlueprintForm({
 				onClose={_handleCloseSidebar}
 				onFetchResults={_handleFetchPreviewSearch}
 				onFocusSXPElement={_handleFocusSXPElement}
+				response={previewInfo.results.response}
 				responseString={previewInfo.results.responseString}
-				totalHits={previewInfo.results.searchHits?.totalHits}
+				searchHits={previewInfo.results.searchHits}
 				visible={openSidebar === SIDEBARS.PREVIEW}
 				warnings={previewInfo.results.warnings}
 			/>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/PreviewSidebar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/PreviewSidebar.js
@@ -36,18 +36,16 @@ const DELTAS = [10, 20, 30, 50];
 
 function PreviewSidebar({
 	errors = [],
+	hits = [],
 	loading,
 	onClose,
 	onFetchResults,
 	onFocusSXPElement,
-	response = {},
 	responseString = '',
-	searchHits = {},
+	totalHits,
 	visible,
 	warnings = [],
 }) {
-	const {hits, totalHits} = searchHits;
-
 	const [activeDelta, setActiveDelta] = useState(10);
 	const [activePage, setActivePage] = useState(1);
 	const [attributes, setAttributes] = useState([]);
@@ -85,19 +83,15 @@ function PreviewSidebar({
 	const _renderHits = () => (
 		<div className="preview-results-list sidebar-body">
 			<ClayList>
-				{hits.map((result, index) => {
-					const responseHit = response.hits?.hits?.[index] || {};
-
-					return (
-						<ResultListItem
-							explanation={responseHit._explanation}
-							fields={result.documentFields}
-							id={responseHit._id}
-							key={responseHit._id}
-							score={responseHit._score}
-						/>
-					);
-				})}
+				{hits.map((result) => (
+					<ResultListItem
+						explanation={result.explanation}
+						fields={result.documentFields}
+						id={result.id}
+						key={result.id}
+						score={result.score}
+					/>
+				))}
 			</ClayList>
 
 			<ClayPaginationBar>
@@ -282,13 +276,13 @@ function PreviewSidebar({
 
 PreviewSidebar.propTypes = {
 	errors: PropTypes.arrayOf(PropTypes.object),
+	hits: PropTypes.arrayOf(PropTypes.object),
 	loading: PropTypes.bool,
 	onClose: PropTypes.func,
 	onFetchResults: PropTypes.func,
 	onFocusSXPElement: PropTypes.func,
-	response: PropTypes.object,
 	responseString: PropTypes.string,
-	searchHits: PropTypes.object,
+	totalHits: PropTypes.number,
 	visible: PropTypes.bool,
 	warnings: PropTypes.arrayOf(PropTypes.object),
 };

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/ResultListItem.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/ResultListItem.js
@@ -12,7 +12,6 @@
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
-import ClayLink from '@clayui/link';
 import ClayList from '@clayui/list';
 import getCN from 'classnames';
 import moment from 'moment';
@@ -31,7 +30,7 @@ const getResultDefaultKeys = (locale) => [
 
 const SXP_BLUEPRINT_FIELD_PREFIX = '_';
 const RESULTS_SHOW_KEYS = ['assetEntryId'];
-const DATE_KEYS = ['createDate', 'modified'];
+const DATE_KEYS = ['birthDate', 'createDate', 'modified'];
 const TRUNCATE_LENGTH = 700;
 
 const sxpBlueprintFieldPrefixRegex = new RegExp(
@@ -63,13 +62,13 @@ function truncateString(value) {
 		: value;
 }
 
-function ResultListItem({item}) {
+function ResultListItem({explanation = {}, fields, id, score = 0}) {
 	const {locale} = useContext(ThemeContext);
 
 	const [collapse, setCollapse] = useState(true);
 
 	const _renderListRow = (property, value) =>
-		value && (
+		value?.values && (
 			<ClayLayout.Row justify="start" key={property}>
 				<ClayLayout.Col className="semibold" size={4}>
 					{removeSXPBlueprintFieldPrefix(property)}
@@ -83,61 +82,42 @@ function ResultListItem({item}) {
 						typeof value === 'object'
 							? localizeDate(
 									property,
-									removeBrackets(JSON.stringify(value))
+									removeBrackets(JSON.stringify(value.values))
 							  )
-							: localizeDate(property, value)
+							: localizeDate(property, value.values)
 					)}
 				</ClayLayout.Col>
 			</ClayLayout.Row>
 		);
 
 	return (
-		<ClayList.Item
-			className="result-list-item"
-			flex
-			key={item[`title_${locale}`]}
-		>
+		<ClayList.Item className="result-list-item" flex key={id}>
 			<ClayList.ItemField>
 				<PreviewModalWithCopyDownload
 					fileName="score_explanation.json"
 					size="lg"
-					text={JSON.stringify(
-						item?._explanation?.details || [],
-						null,
-						2
-					)}
+					text={JSON.stringify(explanation.details || [], null, 2)}
 					title={Liferay.Language.get('score-explanation')}
 				>
 					<ClayButton className="score" displayType="unstyled" small>
-						{item._score.toFixed(2)}
+						{score.toFixed(2)}
 					</ClayButton>
 				</PreviewModalWithCopyDownload>
 			</ClayList.ItemField>
 
 			<ClayList.ItemField expand>
 				<ClayList.ItemTitle>
-					{item.viewURL ? (
-						<ClayLink href={item.viewURL} target="_blank">
-							{item[`title_${locale}`] || item.fullName}
-
-							<ClayIcon
-								className="shortcut-icon"
-								symbol="shortcut"
-							/>
-						</ClayLink>
-					) : (
-						item[`title_${locale}`] || item.fullName
-					)}
+					{fields.assetTitle.values}
 				</ClayList.ItemTitle>
 
 				{getResultDefaultKeys(locale).map((property) =>
-					_renderListRow(property, item[property])
+					_renderListRow(property, fields[property])
 				)}
 
 				{!collapse && (
 					<>
 						{RESULTS_SHOW_KEYS.map((property) =>
-							_renderListRow(property, item[property])
+							_renderListRow(property, fields[property])
 						)}
 
 						<div className="list-group-header">
@@ -146,10 +126,10 @@ function ResultListItem({item}) {
 							</span>
 						</div>
 
-						{Object.keys(item.fields)
+						{Object.keys(fields)
 							.sort()
 							.map((property) =>
-								_renderListRow(property, item.fields[property])
+								_renderListRow(property, fields[property])
 							)}
 					</>
 				)}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/ResultListItem.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/ResultListItem.js
@@ -36,7 +36,6 @@ const TRUNCATE_LENGTH = 700;
 const sxpBlueprintFieldPrefixRegex = new RegExp(
 	`^(${SXP_BLUEPRINT_FIELD_PREFIX})`
 );
-const bracketsQuotesRegex = new RegExp(/[[\]"]/, 'g');
 
 function localizeDate(property, value) {
 	if (DATE_KEYS.includes(property)) {
@@ -52,23 +51,19 @@ function removeSXPBlueprintFieldPrefix(value) {
 	return value.replace(sxpBlueprintFieldPrefixRegex, '');
 }
 
-function removeBrackets(value) {
-	return value.replace(bracketsQuotesRegex, '');
-}
-
 function truncateString(value) {
 	return value.length > TRUNCATE_LENGTH
 		? value.substring(0, TRUNCATE_LENGTH).concat('...')
 		: value;
 }
 
-function ResultListItem({explanation = {}, fields, id, score = 0}) {
+function ResultListItem({explanation = '', fields, id, score = 0}) {
 	const {locale} = useContext(ThemeContext);
 
 	const [collapse, setCollapse] = useState(true);
 
 	const _renderListRow = (property, value) =>
-		value?.values && (
+		value && (
 			<ClayLayout.Row justify="start" key={property}>
 				<ClayLayout.Col className="semibold" size={4}>
 					{removeSXPBlueprintFieldPrefix(property)}
@@ -78,14 +73,7 @@ function ResultListItem({explanation = {}, fields, id, score = 0}) {
 					className={getCN({'text-truncate': collapse})}
 					size={8}
 				>
-					{truncateString(
-						typeof value === 'object'
-							? localizeDate(
-									property,
-									removeBrackets(JSON.stringify(value.values))
-							  )
-							: localizeDate(property, value.values)
-					)}
+					{truncateString(localizeDate(property, value))}
 				</ClayLayout.Col>
 			</ClayLayout.Row>
 		);
@@ -96,7 +84,7 @@ function ResultListItem({explanation = {}, fields, id, score = 0}) {
 				<PreviewModalWithCopyDownload
 					fileName="score_explanation.json"
 					size="lg"
-					text={JSON.stringify(explanation.details || [], null, 2)}
+					text={explanation}
 					title={Liferay.Language.get('score-explanation')}
 				>
 					<ClayButton className="score" displayType="unstyled" small>
@@ -106,9 +94,7 @@ function ResultListItem({explanation = {}, fields, id, score = 0}) {
 			</ClayList.ItemField>
 
 			<ClayList.ItemField expand>
-				<ClayList.ItemTitle>
-					{fields.assetTitle.values}
-				</ClayList.ItemTitle>
+				<ClayList.ItemTitle>{fields.assetTitle}</ClayList.ItemTitle>
 
 				{getResultDefaultKeys(locale).map((property) =>
 					_renderListRow(property, fields[property])

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
@@ -96,6 +96,18 @@ export function parseAndPrettifyJSON(json) {
 	}
 }
 
+const BRACKETS_QUOTES_REGEX = new RegExp(/[[\]"]/, 'g');
+
+/**
+ * Function to remove brackets and quotations from a string.
+ *
+ * @param {String} value String with brackets and quotes
+ * @return {String}
+ */
+export function removeBrackets(value) {
+	return value.replace(BRACKETS_QUOTES_REGEX, '');
+}
+
 /**
  * Function to remove duplicates in an array.
  *
@@ -598,4 +610,34 @@ export function transformToSearchContextAttributes(attributes) {
 			}),
 			{}
 		);
+}
+
+/**
+ * Converts the results from search preview into the format expected
+ * for `hits` property inside PreviewSidebar.
+ *
+ * @param {object} results Contains search hits
+ * @returns {Array}
+ */
+export function transformToSearchPreviewHits(results) {
+	const searchHits = results.searchHits?.hits || [];
+
+	const finalHits = [];
+
+	searchHits.forEach((hit) => {
+		const documentFields = {};
+
+		Object.entries(hit.documentFields).forEach(([key, value]) => {
+			documentFields[key] = removeBrackets(
+				JSON.stringify(value.values || [])
+			);
+		});
+
+		finalHits.push({
+			...hit,
+			documentFields,
+		});
+	});
+
+	return finalHits;
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/PreviewSidebar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/PreviewSidebar.js
@@ -26,9 +26,7 @@ jest.mock(
 
 Liferay.ThemeDisplay.getDefaultLanguageId = () => 'en_US';
 
-const SEARCH_RESULTS = mockSearchResults();
-
-const SEARCH_RESULTS_HITS = JSON.parse(SEARCH_RESULTS.responseString).hits.hits;
+const {response, responseString, searchHits} = mockSearchResults();
 
 function renderPreviewSidebar(props) {
 	return render(
@@ -59,8 +57,9 @@ describe('PreviewSidebar', () => {
 	it('renders the loading icon', () => {
 		const {container} = renderPreviewSidebar({
 			loading: true,
-			responseString: SEARCH_RESULTS.responseString,
-			totalHits: SEARCH_RESULTS.totalHits,
+			response,
+			responseString,
+			searchHits,
 		});
 
 		container.querySelector('.loading-animation');
@@ -68,25 +67,29 @@ describe('PreviewSidebar', () => {
 
 	it('renders the titles for the search results', () => {
 		const {getByText} = renderPreviewSidebar({
-			responseString: SEARCH_RESULTS.responseString,
-			totalHits: SEARCH_RESULTS.totalHits,
+			response,
+			responseString,
+			searchHits,
 		});
 
-		SEARCH_RESULTS_HITS.map((result) => {
-			getByText(result.fields.title_en_US[0]);
+		searchHits.hits.forEach(({documentFields}) => {
+			getByText(documentFields.assetTitle.values);
 		});
 	});
 
 	it('expands the result when clicked on', () => {
 		const {getAllByLabelText, queryAllByText} = renderPreviewSidebar({
-			responseString: SEARCH_RESULTS.responseString,
-			totalHits: SEARCH_RESULTS.totalHits,
+			response,
+			responseString,
+			searchHits,
 		});
 
 		fireEvent.click(getAllByLabelText('expand')[0]);
 
-		Object.keys(SEARCH_RESULTS_HITS[0].fields).map((key) => {
-			queryAllByText(`${SEARCH_RESULTS_HITS[0].fields[key][0]}`);
+		const firstHitDocumentFields = searchHits.hits[0].documentFields;
+
+		Object.keys(firstHitDocumentFields).forEach((key) => {
+			queryAllByText(`${firstHitDocumentFields[key].values}`);
 		});
 	});
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/PreviewSidebar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/PreviewSidebar.js
@@ -13,6 +13,7 @@ import {fireEvent, render} from '@testing-library/react';
 import React from 'react';
 
 import PreviewSidebar from '../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/PreviewSidebar';
+import {transformToSearchPreviewHits} from '../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils';
 import {mockSearchResults} from '../mocks/data';
 
 import '@testing-library/jest-dom/extend-expect';
@@ -26,7 +27,8 @@ jest.mock(
 
 Liferay.ThemeDisplay.getDefaultLanguageId = () => 'en_US';
 
-const {response, responseString, searchHits} = mockSearchResults();
+const SEARCH_RESULTS = mockSearchResults();
+const SEARCH_HITS = transformToSearchPreviewHits(SEARCH_RESULTS);
 
 function renderPreviewSidebar(props) {
 	return render(
@@ -56,10 +58,10 @@ describe('PreviewSidebar', () => {
 
 	it('renders the loading icon', () => {
 		const {container} = renderPreviewSidebar({
+			hits: SEARCH_HITS,
 			loading: true,
-			response,
-			responseString,
-			searchHits,
+			responseString: SEARCH_RESULTS.responseString,
+			totalHits: SEARCH_RESULTS.searchHits.totalHits,
 		});
 
 		container.querySelector('.loading-animation');
@@ -67,29 +69,27 @@ describe('PreviewSidebar', () => {
 
 	it('renders the titles for the search results', () => {
 		const {getByText} = renderPreviewSidebar({
-			response,
-			responseString,
-			searchHits,
+			hits: SEARCH_HITS,
+			responseString: SEARCH_RESULTS.responseString,
+			totalHits: SEARCH_RESULTS.searchHits.totalHits,
 		});
 
-		searchHits.hits.forEach(({documentFields}) => {
-			getByText(documentFields.assetTitle.values);
+		SEARCH_HITS.forEach(({documentFields}) => {
+			getByText(documentFields.assetTitle);
 		});
 	});
 
 	it('expands the result when clicked on', () => {
 		const {getAllByLabelText, queryAllByText} = renderPreviewSidebar({
-			response,
-			responseString,
-			searchHits,
+			hits: SEARCH_HITS,
+			responseString: SEARCH_RESULTS.responseString,
+			totalHits: SEARCH_RESULTS.searchHits.totalHits,
 		});
 
 		fireEvent.click(getAllByLabelText('expand')[0]);
 
-		const firstHitDocumentFields = searchHits.hits[0].documentFields;
-
-		Object.keys(firstHitDocumentFields).forEach((key) => {
-			queryAllByText(`${firstHitDocumentFields[key].values}`);
+		Object.entries(SEARCH_HITS[0].documentFields).forEach(([, value]) => {
+			queryAllByText(value);
 		});
 	});
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/mocks/data.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/mocks/data.js
@@ -187,8 +187,8 @@ export function mockSearchResults(itemsPerPage = 10) {
 
 		documentFields['assetTitle'] = {values: [`Article Number ${i}`]};
 
-		Object.keys(fields).forEach((field) => {
-			documentFields[field] = {values: fields[field]};
+		Object.entries(fields).forEach(([key, value]) => {
+			documentFields[key] = {values: value};
 		});
 
 		hits.push({
@@ -200,7 +200,12 @@ export function mockSearchResults(itemsPerPage = 10) {
 			fields,
 		});
 
-		documents.push({documentFields});
+		documents.push({
+			documentFields,
+			explanation: '',
+			id: `com.liferay.journal.model.JournalArticle_PORTLET_${i}`,
+			score,
+		});
 	}
 
 	const response = {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/mocks/data.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/mocks/data.js
@@ -161,9 +161,35 @@ export function mockClassNames(prefix, isObject = true, itemCount = 10) {
 
 export function mockSearchResults(itemsPerPage = 10) {
 	const hits = [];
+	const documents = [];
 
 	for (var i = 1; i <= itemsPerPage; i++) {
 		const score = Math.random() * 100;
+
+		const fields = {
+			assetEntryId: [`4273${i}`],
+			classPK: ['0'],
+			content_en_US: ['Web Content'],
+			createDate: ['20211102190832'],
+			ddmTemplateKey: ['BASIC-WEB-CONTENT'],
+			defaultLanguageId: ['en_US'],
+			entryClassName: ['com.liferay.journal.model.JournalArticle'],
+			entryClassPK: ['40116'],
+			modified: ['20211102192146'],
+			scopeGroupId: ['20123'],
+			title_en_US: [`Article Number ${i}`],
+			userId: ['20127'],
+			userName: ['test test'],
+			visible: ['true'],
+		};
+
+		const documentFields = {};
+
+		documentFields['assetTitle'] = {values: [`Article Number ${i}`]};
+
+		Object.keys(fields).forEach((field) => {
+			documentFields[field] = {values: fields[field]};
+		});
 
 		hits.push({
 			_explanation: {},
@@ -171,37 +197,34 @@ export function mockSearchResults(itemsPerPage = 10) {
 			_index: 'liferay-20099',
 			_score: score,
 			_type: 'LiferayDocumentType',
-			fields: {
-				classPK: ['0'],
-				content_en_US: ['Web Content'],
-				createDate: ['20211102190832'],
-				ddmTemplateKey: ['BASIC-WEB-CONTENT'],
-				defaultLanguageId: ['en_US'],
-				entryClassName: ['com.liferay.journal.model.JournalArticle'],
-				entryClassPK: ['40116'],
-				modified: ['20211102192146'],
-				scopeGroupId: ['20123'],
-				title_en_US: [`Article Number ${i}`],
-				userId: ['20127'],
-				userName: ['test test'],
-				visible: ['true'],
-			},
+			fields,
 		});
+
+		documents.push({documentFields});
 	}
+
+	const response = {
+		hits: {
+			hits,
+			total: {
+				value: 2,
+			},
+		},
+		timed_out: false,
+	};
+
+	const searchHits = {
+		hits: documents,
+		maxScore: 65.878,
+		totalHits: 1000,
+	};
 
 	return {
 		page: 0,
 		pageSize: itemsPerPage,
 		requestString: '',
-		responseString: JSON.stringify({
-			hits: {
-				hits,
-				total: {
-					value: 2,
-				},
-			},
-			timed_out: false,
-		}),
-		totalHits: 1000,
+		response,
+		responseString: JSON.stringify(response),
+		searchHits,
 	};
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-145145 - Preview: render result title from calculated field "assetTitle"

Some notes:
- Updated props in `PreviewSidebar` and `ResultListItem`
- Used `assetTitle` as the title
- Removed `viewURL` blurb (idk if we're using it anymore)
- Explanation and score are taken from the `response.hits.hits`, but the rest of the fields are taken from `searchHits.hits` which have `documentFields` (as Petteri mentioned). I just used the index to locate the other, since it seems like the orders are the same.
- Updated some places where values are read since `documentFields` is actually structured like `{values: ["Test Test"]}`
- Frontend test updates

Hope this makes sense! Let me know what you think 💭 