### PR TITLE
Demo: Custom content renderer with fuzzy text match styling

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/OrderableTable.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/OrderableTable.scss
@@ -5,16 +5,19 @@
 		text-align: center;
 	}
 
-	.orderable-table.table-autofit td {
-		width: inherit;
+	.orderable-table.table-autofit {
+		td,
+		th {
+			width: inherit;
 
-		&.actions-cell {
-			padding-right: 18px;
-			width: 0;
-		}
+			&.actions-cell {
+				padding-right: 18px;
+				width: 0;
+			}
 
-		&.drag-handle-cell {
-			width: 0;
+			&.drag-handle-cell {
+				width: 0;
+			}
 		}
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -134,6 +134,7 @@ const OrderableTableRow = ({
 						item.label || Liferay.Language.get('item')
 					)}
 					displayType={null}
+					size="sm"
 					symbol="drag"
 				/>
 			</ClayTable.Cell>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -36,12 +36,19 @@ interface Action {
 	onClick: Function;
 }
 
+interface ContentRendererProps {
+	item: any;
+}
+
+interface Field {
+	contentRenderer?: React.FC<ContentRendererProps>;
+	label: string;
+	name: string;
+}
+
 interface OrderableTableRowProps {
 	actions?: Array<Action>;
-	fields: Array<{
-		label: string;
-		name: string;
-	}>;
+	fields: Array<Field>;
 	index: number;
 	item: any;
 	onOrderChange: Function;
@@ -131,6 +138,18 @@ const OrderableTableRow = ({
 			</ClayTable.Cell>
 
 			{fields.map((field) => {
+				if (field.contentRenderer) {
+					const ContentRenderer = field.contentRenderer as React.FC<
+						ContentRendererProps
+					>;
+
+					return (
+						<ClayTable.Cell key={field.name}>
+							<ContentRenderer item={item} />
+						</ClayTable.Cell>
+					);
+				}
+
 				const itemFieldValue = String(item[field.name]);
 
 				const fuzzyMatch = fuzzy.match(
@@ -200,10 +219,7 @@ const OrderableTableRow = ({
 interface OrderableTableProps {
 	actions?: Array<Action>;
 	disableSave?: boolean;
-	fields: Array<{
-		label: string;
-		name: string;
-	}>;
+	fields: Array<Field>;
 	items: Array<any>;
 	noItemsButtonLabel: string;
 	noItemsDescription: string;
@@ -242,9 +258,13 @@ const OrderableTable = ({
 		setItems(
 			query
 				? initialItems.filter((item) =>
-						fields.some((field) =>
-							String(item[field.name]).match(regexp)
-						)
+						fields.some((field) => {
+							if (field.contentRenderer) {
+								return false;
+							}
+
+							return String(item[field.name]).match(regexp);
+						})
 				  ) || []
 				: initialItems
 		);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -263,13 +263,9 @@ const OrderableTable = ({
 		setItems(
 			query
 				? initialItems.filter((item) =>
-						fields.some((field) => {
-							if (field.contentRenderer) {
-								return false;
-							}
-
-							return String(item[field.name]).match(regexp);
-						})
+						fields.some((field) =>
+							String(item[field.name]).match(regexp)
+						)
 				  ) || []
 				: initialItems
 		);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -42,6 +42,7 @@ interface ContentRendererProps {
 
 interface Field {
 	contentRenderer?: React.FC<ContentRendererProps>;
+	headingTitle?: boolean;
 	label: string;
 	name: string;
 }
@@ -159,7 +160,10 @@ const OrderableTableRow = ({
 				);
 
 				return (
-					<ClayTable.Cell key={field.name}>
+					<ClayTable.Cell
+						headingTitle={field.headingTitle}
+						key={field.name}
+					>
 						{fuzzyMatch ? (
 							<span
 								dangerouslySetInnerHTML={{

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -321,7 +321,10 @@ const OrderableTable = ({
 								<ClayTable.Cell className="drag-handle-cell" />
 
 								{fields.map((field) => (
-									<ClayTable.Cell key={field.name}>
+									<ClayTable.Cell
+										headingCell
+										key={field.name}
+									>
 										{field.label}
 									</ClayTable.Cell>
 								))}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -40,8 +40,13 @@ interface ContentRendererProps {
 	item: any;
 }
 
+interface ContentRenderer {
+	component: React.FC<ContentRendererProps>;
+	textMatch?: Function;
+}
+
 interface Field {
-	contentRenderer?: React.FC<ContentRendererProps>;
+	contentRenderer?: ContentRenderer;
 	headingTitle?: boolean;
 	label: string;
 	name: string;
@@ -141,13 +146,12 @@ const OrderableTableRow = ({
 
 			{fields.map((field) => {
 				if (field.contentRenderer) {
-					const ContentRenderer = field.contentRenderer as React.FC<
-						ContentRendererProps
-					>;
+					const Component = field.contentRenderer
+						.component as React.FC<ContentRendererProps>;
 
 					return (
 						<ClayTable.Cell key={field.name}>
-							<ContentRenderer item={item} />
+							<Component item={item} />
 						</ClayTable.Cell>
 					);
 				}
@@ -263,9 +267,15 @@ const OrderableTable = ({
 		setItems(
 			query
 				? initialItems.filter((item) =>
-						fields.some((field) =>
-							String(item[field.name]).match(regexp)
-						)
+						fields.some((field) => {
+							if (field.contentRenderer?.textMatch) {
+								return String(
+									field.contentRenderer.textMatch(item)
+								).match(regexp);
+							}
+
+							return String(item[field.name]).match(regexp);
+						})
 				  ) || []
 				: initialItems
 		);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -38,6 +38,7 @@ interface Action {
 
 interface ContentRendererProps {
 	item: any;
+	query: string;
 }
 
 interface ContentRenderer {
@@ -151,7 +152,7 @@ const OrderableTableRow = ({
 
 					return (
 						<ClayTable.Cell key={field.name}>
-							<Component item={item} />
+							<Component item={item} query={query} />
 						</ClayTable.Cell>
 					);
 				}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -28,6 +28,10 @@ import {getFields} from '../api';
 import OrderableTable from '../components/OrderableTable';
 import RequiredMark from '../components/RequiredMark';
 
+interface ContentRendererProps {
+	item: FDSSort;
+}
+
 interface Field {
 	format: string;
 	label: string;
@@ -77,6 +81,16 @@ function alertSuccess() {
 		type: 'success',
 	});
 }
+
+const SortingDirectionContentRenderer = ({item}: ContentRendererProps) => {
+	return (
+		<span>
+			{item.sortingDirection === SORTING_DIRECTION.ASCENDING.value
+				? SORTING_DIRECTION.ASCENDING.label
+				: SORTING_DIRECTION.DESCENDING.label}
+		</span>
+	);
+};
 
 const AddFDSSortModalContent = ({
 	closeModal,
@@ -327,6 +341,7 @@ const Sorting = ({fdsView, fdsViewsURL}: FDSViewSectionInterface) => {
 								name: 'fieldName',
 							},
 							{
+								contentRenderer: SortingDirectionContentRenderer,
 								label: Liferay.Language.get('value'),
 								name: 'sortingDirection',
 							},

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -337,6 +337,7 @@ const Sorting = ({fdsView, fdsViewsURL}: FDSViewSectionInterface) => {
 						disableSave={!newFDSSortsOrder.length}
 						fields={[
 							{
+								headingTitle: true,
 								label: Liferay.Language.get('name'),
 								name: 'fieldName',
 							},

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -82,7 +82,13 @@ function alertSuccess() {
 	});
 }
 
-const SortingDirectionContentRenderer = ({item}: ContentRendererProps) => {
+const sortingDirectionTextMatch = (item: FDSSort) => {
+	return item.sortingDirection === SORTING_DIRECTION.ASCENDING.value
+		? SORTING_DIRECTION.ASCENDING.label
+		: SORTING_DIRECTION.DESCENDING.label;
+};
+
+const SortingDirectionComponent = ({item}: ContentRendererProps) => {
 	return (
 		<span>
 			{item.sortingDirection === SORTING_DIRECTION.ASCENDING.value
@@ -342,7 +348,10 @@ const Sorting = ({fdsView, fdsViewsURL}: FDSViewSectionInterface) => {
 								name: 'fieldName',
 							},
 							{
-								contentRenderer: SortingDirectionContentRenderer,
+								contentRenderer: {
+									component: SortingDirectionComponent,
+									textMatch: sortingDirectionTextMatch,
+								},
 								label: Liferay.Language.get('value'),
 								name: 'sortingDirection',
 							},

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -19,9 +19,10 @@ import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal from '@clayui/modal';
 import {fetch, navigate, openModal, openToast} from 'frontend-js-web';
+import fuzzy from 'fuzzy';
 import React, {useEffect, useState} from 'react';
 
-import {API_URL, OBJECT_RELATIONSHIP} from '../Constants';
+import {API_URL, FUZZY_OPTIONS, OBJECT_RELATIONSHIP} from '../Constants';
 import {FDSViewSectionInterface} from '../FDSView';
 import {FDSViewType} from '../FDSViews';
 import {getFields} from '../api';
@@ -30,6 +31,7 @@ import RequiredMark from '../components/RequiredMark';
 
 interface ContentRendererProps {
 	item: FDSSort;
+	query: string;
 }
 
 interface Field {
@@ -88,12 +90,25 @@ const sortingDirectionTextMatch = (item: FDSSort) => {
 		: SORTING_DIRECTION.DESCENDING.label;
 };
 
-const SortingDirectionComponent = ({item}: ContentRendererProps) => {
+const SortingDirectionComponent = ({item, query}: ContentRendererProps) => {
+	const itemFieldValue =
+		item.sortingDirection === SORTING_DIRECTION.ASCENDING.value
+			? SORTING_DIRECTION.ASCENDING.label
+			: SORTING_DIRECTION.DESCENDING.label;
+
+	const fuzzyMatch = fuzzy.match(query, itemFieldValue, FUZZY_OPTIONS);
+
 	return (
 		<span>
-			{item.sortingDirection === SORTING_DIRECTION.ASCENDING.value
-				? SORTING_DIRECTION.ASCENDING.label
-				: SORTING_DIRECTION.DESCENDING.label}
+			{fuzzyMatch ? (
+				<span
+					dangerouslySetInnerHTML={{
+						__html: fuzzyMatch.rendered,
+					}}
+				/>
+			) : (
+				<span>{itemFieldValue}</span>
+			)}
 		</span>
 	);
 };

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
@@ -12,21 +12,26 @@
  * details.
  */
 
-/// <reference types="react" />
-
+import React from 'react';
 import '../../css/OrderableTable.scss';
 interface Action {
 	icon: string;
 	label: string;
 	onClick: Function;
 }
+interface ContentRendererProps {
+	item: any;
+}
+interface Field {
+	contentRenderer?: React.FC<ContentRendererProps>;
+	headingTitle?: boolean;
+	label: string;
+	name: string;
+}
 interface OrderableTableProps {
 	actions?: Array<Action>;
 	disableSave?: boolean;
-	fields: Array<{
-		label: string;
-		name: string;
-	}>;
+	fields: Array<Field>;
 	items: Array<any>;
 	noItemsButtonLabel: string;
 	noItemsDescription: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
@@ -21,9 +21,14 @@ interface Action {
 }
 interface ContentRendererProps {
 	item: any;
+	query: string;
+}
+interface ContentRenderer {
+	component: React.FC<ContentRendererProps>;
+	textMatch?: Function;
 }
 interface Field {
-	contentRenderer?: React.FC<ContentRendererProps>;
+	contentRenderer?: ContentRenderer;
 	headingTitle?: boolean;
 	label: string;
 	name: string;


### PR DESCRIPTION
See last 3 commits: f8816edb909830997afa4849eb33355d0f500cd3...14d761fed28f5c6ad8bd938f472e13cdb8fe2de5

- Supports a separate property for `component` and `textMatch` function.

```
fields={[
	{
		headingTitle: true,
		label: Liferay.Language.get('name'),
		name: 'fieldName',
	},
	{
		contentRenderer: {
			component: SortingDirectionComponent,
			textMatch: sortingDirectionTextMatch,
		},
		label: Liferay.Language.get('value'),
		name: 'sortingDirection',
	},
]}
```
https://github.com/thektan/liferay-portal/assets/4496722/61e38bed-52bc-4aba-bb15-80fc8515a699

